### PR TITLE
Fill username from UUID

### DIFF
--- a/helusers/models.py
+++ b/helusers/models.py
@@ -3,6 +3,9 @@ import logging
 from django.db import models
 from django.contrib.auth.models import AbstractUser as DjangoAbstractUser
 
+from .utils import uuid_to_username
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -11,9 +14,22 @@ class AbstractUser(DjangoAbstractUser):
     department_name = models.CharField(max_length=50, null=True, blank=True)
 
     def save(self, *args, **kwargs):
+        self.clean()
+        return super(AbstractUser, self).save(*args, **kwargs)
+
+    def clean(self):
+        self._make_sure_uuid_is_set()
+        if not self.username:
+            self.set_username_from_uuid()
+        super(AbstractUser, self).clean()
+
+    def _make_sure_uuid_is_set(self):
         if self.uuid is None:
             self.uuid = uuid.uuid1()
-        return super(AbstractUser, self).save(*args, **kwargs)
+
+    def set_username_from_uuid(self):
+        self._make_sure_uuid_is_set()
+        self.username = uuid_to_username(self.uuid)
 
     class Meta:
         abstract = True

--- a/helusers/utils.py
+++ b/helusers/utils.py
@@ -1,0 +1,30 @@
+import base64
+from uuid import UUID
+
+
+def uuid_to_username(uuid):
+    """
+    Convert UUID to username.
+
+    >>> uuid_to_username('00fbac99-0bab-5e66-8e84-2e567ea4d1f6')
+    'u-ad52zgilvnpgnduefzlh5jgr6y'
+
+    >>> uuid_to_username(UUID('00fbac99-0bab-5e66-8e84-2e567ea4d1f6'))
+    'u-ad52zgilvnpgnduefzlh5jgr6y'
+    """
+    uuid_data = getattr(uuid, 'bytes', None) or UUID(uuid).bytes
+    b32coded = base64.b32encode(uuid_data)
+    return 'u-' + b32coded.decode('ascii').replace('=', '').lower()
+
+
+def username_to_uuid(username):
+    """
+    Convert username to UUID.
+
+    >>> username_to_uuid('u-ad52zgilvnpgnduefzlh5jgr6y')
+    UUID('00fbac99-0bab-5e66-8e84-2e567ea4d1f6')
+    """
+    if not username.startswith('u-') or len(username) != 28:
+        raise ValueError('Not an UUID based username: %r' % (username,))
+    decoded = base64.b32decode(username[2:].upper() + '======')
+    return UUID(bytes=decoded)


### PR DESCRIPTION
Allow creating users without username by filling their username from the
uuid field if no username is already set.

Also define a new method `set_username_from_uuid` for overriding the
username with a value generated from the uuid.  This can be used e.g. in
social logins to force username to the UUID format.