### PR TITLE
Fix MANIFEST.in and tune ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 *.pyc
+/dist
+/build
 /django_helusers.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include LICENSE
 include README.rst
-recursive-include helusers *
+recursive-include helusers *.html


### PR DESCRIPTION
Using `recursive-include helusers *` includes also pyc files, which
shouldn't go into sdist or wheel archives.  Replace `*` with `*.html` to
include just the html files.  Python files (`*.py`) are always included.

Also ignore dist and build directories, which are generated when
building packages with setup.py.