### PR TITLE
migrations: Downgrade dependencies to auth

### DIFF
--- a/helusers/migrations/0001_add_ad_groups.py
+++ b/helusers/migrations/0001_add_ad_groups.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('auth', '0008_alter_user_username_max_length'),
+        ('auth', '0001_initial'),
     ]
 
     operations = [


### PR DESCRIPTION
Some of the applications which use django-helusers might be using older
Django than 1.11.  Change the dependency to earlier migration to allow
using django-helusers with older Django versions (1.8, 1.9 or 1.10).