### PR TITLE
Add support for controlling Tunnistamo login process language

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ AUTHENTICATION_BACKENDS = (
 AUTH_USER_MODEL = 'users.User'
 LOGIN_REDIRECT_URL = '/'
 ```
+- If you need to be able to control Tunnistamo login process language, add also setting
+```python
+SOCIAL_AUTH_TUNNISTAMO_AUTH_EXTRA_ARGUMENTS = {'ui_locales': 'fi'}
+```
+`fi` there is the language code that will be used when no language is requested, so change it if you you prefer some
+other default language. If you don't want to set a default language at all, use an empty string `""` as the language
+code.
+
+When that setting is in place, languages can be requested using query param `ui_locales=<language code>` when starting
+the login process, for example in your template
+```
+<a href="{% url 'helusers:auth_login' %}?next=/foobar/&ui_locales=en">Login in English</a>
+```
 
 - Add URLs entries (to `<project>/urls.py`):
 

--- a/helusers/views.py
+++ b/helusers/views.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+from urllib.parse import urlencode
+
 from django.contrib.auth.views import LogoutView as DjangoLogoutView
 from django.views.generic.base import RedirectView
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -5,6 +8,8 @@ from django.http import HttpResponseRedirect
 from django.contrib import messages
 from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
+
+LANGUAGE_FIELD_NAME = 'ui_locales'
 
 
 class LogoutView(DjangoLogoutView):
@@ -31,6 +36,14 @@ class LoginView(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         url = reverse('social:begin', kwargs=dict(backend='tunnistamo'))
         redirect_to = self.request.GET.get(REDIRECT_FIELD_NAME)
+        lang = self.request.GET.get(LANGUAGE_FIELD_NAME)
+
+        query_params = OrderedDict()
         if redirect_to:
-            url += '?%s=%s' % (REDIRECT_FIELD_NAME, redirect_to)
+            query_params[REDIRECT_FIELD_NAME] = redirect_to
+        if lang:
+            query_params[LANGUAGE_FIELD_NAME] = lang
+        if query_params:
+            url += '?' + urlencode(query_params)
+
         return url


### PR DESCRIPTION
Tunnistamo login process language can be changed using query parameter "ui_locales".
Before this commit helusers login view did not pass that parameter to Tunnistamo.