### PR TITLE
Allow API scopes to start with http

### DIFF
--- a/helusers/pipeline.py
+++ b/helusers/pipeline.py
@@ -82,7 +82,7 @@ def fetch_api_tokens(details, backend, response, user=None, social=None, request
 
     scopes = set(backend.get_scope())
     # slightly ghetto-style filtering, but it works for now
-    api_scopes = {s for s in scopes if s.startswith('https://')}
+    api_scopes = {s for s in scopes if s.startswith(('https://', 'http://'))}
     tunnistamo_scopes = scopes - api_scopes
 
     request.session['access_token_scope'] = list(tunnistamo_scopes)


### PR DESCRIPTION
When developing some projects locally, it is much more
convenient to have them at the regular http, in order to avoid
certificate management work for a local env.