### PR TITLE
Add setting to hide the username/password form in Django admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,9 @@ TEMPLATES = [
     }
 ]
 ```
+
+### Disabling password logins
+
+If you're not allowing users to log in with passwords, you may disable the
+username/password form from Django admin login page by setting `HELUSERS_PASSWORD_LOGIN_DISABLED`
+to `True`.

--- a/helusers/admin.py
+++ b/helusers/admin.py
@@ -63,6 +63,9 @@ class AdminSite(admin.AdminSite):
             ret['base_site_template'] = 'admin/base_site_grappelli.html'
         else:
             ret['base_site_template'] = 'admin/base_site_default.html'
+
+        ret['password_login_disabled'] = getattr(settings, 'HELUSERS_PASSWORD_LOGIN_DISABLED', False)
+
         return ret
 
 

--- a/helusers/templates/admin/hel_login.html
+++ b/helusers/templates/admin/hel_login.html
@@ -1,6 +1,17 @@
 {% extends "admin/login.html" %}
 {% load static %}
 
+{% block extrastyle %}
+{{ block.super }}
+{% if password_login_disabled %}
+<style>
+    #content-main form {
+        display: none;
+    }
+</style>
+{% endif %}
+{% endblock %}
+
 {% block content %}
 {% if helsinki_provider_installed %}
 <div id="helsinki-login"{% if grappelli_installed %} style="display: none;"{% endif %}>
@@ -10,12 +21,15 @@
             <button style="margin-left: 9em; width: auto;" class="button grp-button grp-default" type="button">Helsinki Login</button>
         </a>
     </div>
+{% if not password_login_disabled %}
     <p>
         Jos sinulla on erilliset ylläpitotunnukset, kirjaudu sisään käyttäjätunnuksella
         ja salasanalla.
     </p>
+{% endif %}
 </div>
 {% endif %}
+
 {{ block.super }}
 {% if grappelli_installed %}
 <script type="text/javascript">


### PR DESCRIPTION
The form is found to confuse users, and it is unnecessary anyway if no passwords are configured for users.