### PR TITLE
Fix JWTAuthentication's active user check

### DIFF
--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -30,13 +30,13 @@ def patch_jwt_settings():
 
 class JWTAuthentication(JSONWebTokenAuthentication):
     def authenticate_credentials(self, payload):
-        user = super().authenticate_credentials(payload)
+        user = get_or_create_user(payload)
 
         if user and not user.is_active:
             msg = _('User account is disabled.')
             raise exceptions.AuthenticationFailed(msg)
 
-        return get_or_create_user(payload)
+        return user
 
 
 def get_user_id_from_payload_handler(payload):

--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from rest_framework import exceptions
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 from rest_framework_jwt.settings import api_settings
 
@@ -29,6 +30,12 @@ def patch_jwt_settings():
 
 class JWTAuthentication(JSONWebTokenAuthentication):
     def authenticate_credentials(self, payload):
+        user = super().authenticate_credentials(payload)
+
+        if user and not user.is_active:
+            msg = _('User account is disabled.')
+            raise exceptions.AuthenticationFailed(msg)
+
         return get_or_create_user(payload)
 
 


### PR DESCRIPTION
`authenticate_crendetials` got `user` from `super` instead of `get_or_create_user`.

Calling super caused 401 error with `'Invalid signature.'`.

Changed to use `get_or_create_user` instead, as the method did before active user check.