### PR TITLE
Fix JWTAuthentication active user check

### DIFF
--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -30,13 +30,13 @@ def patch_jwt_settings():
 
 class JWTAuthentication(JSONWebTokenAuthentication):
     def authenticate_credentials(self, payload):
-        user = super().authenticate_credentials(payload)
+        user = get_or_create_user(payload)
 
         if user and not user.is_active:
             msg = _('User account is disabled.')
             raise exceptions.AuthenticationFailed(msg)
 
-        return get_or_create_user(payload)
+        return user
 
 
 def get_user_id_from_payload_handler(payload):


### PR DESCRIPTION
`authenticate_crendetials` got `user` from `super` instead of `get_or_create_user`.

Calling super caused 401 error with `'Invalid signature.'`.

Changed to use `get_or_create_user` instead, as the method did before active user check.