### PR TITLE
Restructure README, fixing INSTALLED_APPS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,29 @@
 
 # Django app for City of Helsinki user infrastructure
 
-## Installation
+django-helusers is your friendly app for bolting authentication into Django projects for City of Helsinki. It provides the following functionalities:
 
-First, install the pip package.
+* baseline User model
+* authentication against Tunnistamo, an OIDC service for authenticating against multiple backends
+* augmented login template for for Django admin, allowing tunnistamo login
+* mapping from Tunnistamo provided AD groups to Django groups
+* integration with Django Rest Framework authentication
+* authenticating DRF requests using a Tunnnistamo specific "API Token"
 
-```bash
-pip install django-helusers
-```
+## Adding django-helusers your Django project
 
-Second, implement your own custom User model in your application's
-`models.py`.
+Add:
+* `django-helusers`
+* `social-auth-app-django`
+to your dependency management list. Django-helusers depends on
+`social-auth-app-django` for implementation of the OIDC dance.
+
+### Adding user model
+
+helusers provides a baseline user model adding fields for Helsinki
+specific information. As per Django [best practice]
+(https://docs.djangoproject.com/en/3.0/topics/auth/customizing/#using-a-custom-user-model-when-starting-a-project)
+you should subclass this model to make future customization easier:
 
 ```python
 
@@ -26,48 +39,62 @@ class User(AbstractUser):
     pass
 ```
 
-### Configuration of the auth provider
+and reference it in settings.py:
 
-- Add `social-auth-app-django` to your `requirements.in` or `requirements.txt` file and install the package.
-- Add `helusers` and `social_django` to the `INSTALLED_APPS` setting:
+```python
+# myproject/settings.py
+
+AUTH_USER_MODEL = 'users.User'
+```
+
+### Adding django-helusers Django apps
+
+Django-helusers provides two Django apps: `HelusersConfig` provides the models
+needed for helusers to work and `HelusersAdminConfig` reconfigures Django admin
+to work with helusers, including authentication to admin using OIDC.
+
+Additionally `social_django` app is needed for the underlying python-social-auth.
+
+Add these apps to your `INSTALLED_APPS` in settings.py:
 
 ```python
 INSTALLED_APPS = (
-    'helusers',
+    'helusers.apps.HelusersConfig',
+    'helusers.apps.HelusersAdminConfig',
     ...
     'social_django',
     ...
 )
 ```
 
-***Note*** `helusers` must be the first one in the list to properly override the default admin site templates.
+***Note*** `helusers.apps.*` must be before anything else providing admin
+templates in INSTALLED_APPS.
 
-- Configure the following settings:
+### Adding Tunnistamo authentication
+
+django-helusers ships with backend for authenticating against Tunnistamo
+using OIDC. There is also a deprecated legacy OAuth2 backend using
+allauth framework.
+
+Typically you would want to support authenticating using both OIDC and local
+database tables. Local users are useful for initial django admin login, before
+you've delegated permissions to users coming through OIDC.
+
+Add backend configuration to your `settings.py`:
 
 ```python
 AUTHENTICATION_BACKENDS = (
     'helusers.tunnistamo_oidc.TunnistamoOIDCAuth',
     'django.contrib.auth.backends.ModelBackend',
 )
-
-AUTH_USER_MODEL = 'users.User'
 LOGIN_REDIRECT_URL = '/'
 ```
-- If you need to be able to control Tunnistamo login process language, add also setting
-```python
-SOCIAL_AUTH_TUNNISTAMO_AUTH_EXTRA_ARGUMENTS = {'ui_locales': 'fi'}
-```
-`fi` there is the language code that will be used when no language is requested, so change it if you you prefer some
-other default language. If you don't want to set a default language at all, use an empty string `""` as the language
-code.
 
-When that setting is in place, languages can be requested using query param `ui_locales=<language code>` when starting
-the login process, for example in your template
-```
-<a href="{% url 'helusers:auth_login' %}?next=/foobar/&ui_locales=en">Login in English</a>
-```
+`LOGIN_REDIRECT_URL` is the default landing URL after succesful login, if your
+form did not specify anything else.
 
-- Add URLs entries (to `<project>/urls.py`):
+You will also need to add `python-social-auth` URLS to your URL dispatcher
+configuration (`urls.py`):
 
 ```python
 urlpatterns = patterns('',
@@ -77,26 +104,16 @@ urlpatterns = patterns('',
 )
 ```
 
-- Configure your client ID, secret and OIDC endpoint locally (for example in `local_settings.py`):
-
-```python
-TUNNISTAMO_BASE_URL = 'https://tunnistamo.example.com'
-SOCIAL_AUTH_TUNNISTAMO_KEY = 'abcd-12345-abcd-12356789'
-SOCIAL_AUTH_TUNNISTAMO_SECRET = 'abcd1234abcd1234abcd1234abcd1234'
-SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT = TUNNISTAMO_BASE_URL + '/openid'
-```
-
-- Set the session serializer to PickleSerializer
-
-helusers stores the access token expiration time as a datetime which is not
-serializable to JSON, so Django needs to be configured to use the built-in
-PickeSerializer:
+Finally, you will need to configure your SESSION_SERIALIZER. helusers stores
+the access token expiration time as a datetime which is not serializable
+to JSON, so Django needs to be configured to use the built-in
+PickleSerializer:
 
 ```python
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 ```
 
-### Configuration of the API authentication (using JWT tokens)
+### Configuration of the DRF API authentication (using JWT tokens)
 
 - Configure REST framework to use the `ApiTokenAuthentication` class in `settings.py`:
 
@@ -119,7 +136,7 @@ OIDC_API_TOKEN_AUTH = {
 }
 ```
 
-### Context processor
+### Adding tunnistamo URL to template context
 
 If you need to access the Tunnistamo API from your JS code, you can include
 the Tunnistamo base URL in your template context using helusers's context processor:
@@ -135,6 +152,50 @@ TEMPLATES = [
     }
 ]
 ```
+
+### Carrying language preference from your application to Tunnistamo
+
+Tunnistamo (per the OIDC specs) allows clients to specify the language used for
+the login process. This allows you to carry your applications language setting
+to the login screens presented by Tunnistamo.
+
+Configure `python-social-auth` to pass the necessary argument through its
+login view:
+```python
+SOCIAL_AUTH_TUNNISTAMO_AUTH_EXTRA_ARGUMENTS = {'ui_locales': 'fi'}
+```
+`fi` there is the language code that will be used when no language is requested, so change it if you you prefer some
+other default language. If you don't want to set a default language at all, use an empty string `""` as the language
+code.
+
+When this setting is in place, languages can be requested using query param `ui_locales=<language code>` when starting
+the login process, for example in your template
+```
+<a href="{% url 'helusers:auth_login' %}?next=/foobar/&ui_locales=en">Login in English</a>
+```
+
+## Configuring your installation
+
+Each installation ("client" in OIDC parlance) will need its own configuration in Tunnistamo and
+matching configuration in your project config file. Usually three pieces of information are needed:
+* client ID
+* client secret
+* Tunnistamo OIDC endpoint
+
+Additionally you will need to provide your "callback URL" to the folks configuring Tunnistamo.
+This is implemented by `python-social-auth` and will, by default, be
+`https://app.domain/auth/complete/tunnistamo/`. During development on your own laptor, your
+`app.domain` would be `localhost`.
+
+After you've received your client ID, client secret and Tunnistamo OIDC endpoint you would
+configure them as follows:
+```python
+SOCIAL_AUTH_TUNNISTAMO_KEY = 'abcd-12345-abcd-12356789'
+SOCIAL_AUTH_TUNNISTAMO_SECRET = 'abcd1234abcd1234abcd1234abcd1234'
+SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT = https://tunnistamo.example.com/
+```
+
+Note that `client ID` becomes `KEY` and `client secret` becomes `SECRET`.
 
 ### Disabling password logins
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ django-helusers is your friendly app for bolting authentication into Django proj
 ## Adding django-helusers your Django project
 
 Add:
+
 * `django-helusers`
 * `social-auth-app-django`
+
 to your dependency management list. Django-helusers depends on
 `social-auth-app-django` for implementation of the OIDC dance.
 
 ### Adding user model
 
 helusers provides a baseline user model adding fields for Helsinki
-specific information. As per Django [best practice]
-(https://docs.djangoproject.com/en/3.0/topics/auth/customizing/#using-a-custom-user-model-when-starting-a-project)
+specific information. As per Django [best practice](https://docs.djangoproject.com/en/3.0/topics/auth/customizing/#using-a-custom-user-model-when-starting-a-project)
 you should subclass this model to make future customization easier:
 
 ```python
@@ -93,7 +94,7 @@ LOGIN_REDIRECT_URL = '/'
 `LOGIN_REDIRECT_URL` is the default landing URL after succesful login, if your
 form did not specify anything else.
 
-You will also need to add `python-social-auth` URLS to your URL dispatcher
+You will also need to add `python-social-auth` URLs to your URL dispatcher
 configuration (`urls.py`):
 
 ```python
@@ -184,7 +185,7 @@ matching configuration in your project config file. Usually three pieces of info
 
 Additionally you will need to provide your "callback URL" to the folks configuring Tunnistamo.
 This is implemented by `python-social-auth` and will, by default, be
-`https://app.domain/auth/complete/tunnistamo/`. During development on your own laptor, your
+`https://app.domain/auth/complete/tunnistamo/`. During development on your own laptor your
 `app.domain` would be `localhost`.
 
 After you've received your client ID, client secret and Tunnistamo OIDC endpoint you would


### PR DESCRIPTION
Most important change here is documenting the need for both AdminConfig and Appconfig in INSTALLED_APPS.

I also re-arranged the file to separate installation (when project starts to use django-helusers) and configuration (when project is made accessible at some URL).