### PR TITLE
Allow editing AD groups through admin, try to clarify apps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ AUTH_USER_MODEL = 'users.User'
 
 ### Adding django-helusers Django apps
 
-Django-helusers provides two Django apps: `HelusersConfig` provides the models
-needed for helusers to work and `HelusersAdminConfig` reconfigures Django admin
-to work with helusers, including authentication to admin using OIDC.
+Django-helusers provides two Django apps: `HelusersConfig` provides the
+models and templates needed for helusers to work and `HelusersAdminConfig`
+reconfigures Django admin to work with helusers. Latter includes adding
+Tunnistamo login button to admin login screen.
 
 Additionally `social_django` app is needed for the underlying python-social-auth.
 
@@ -68,8 +69,14 @@ INSTALLED_APPS = (
 )
 ```
 
-***Note*** `helusers.apps.*` must be before anything else providing admin
-templates in INSTALLED_APPS.
+Us usual with `INSTALLED_APPS`, ordering matters. `HelusersConfig` must come
+before `HelusersAdminConfig` and anything else providing admin templates.
+Unless, of course, you wish to override the admin templates provided here.
+
+One possible gotcha is, if you've added custom views to admin without
+forwarding context from `each_context` to the your template.  Helusers
+templates except variables from `each_context` and will break if they are
+missing.
 
 ### Adding Tunnistamo authentication
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ AUTH_USER_MODEL = 'users.User'
 
 Django-helusers provides two Django apps: `HelusersConfig` provides the
 models and templates needed for helusers to work and `HelusersAdminConfig`
-reconfigures Django admin to work with helusers. Latter includes adding
-Tunnistamo login button to admin login screen.
+reconfigures Django admin to work with helusers. The latter includes adding
+a Tunnistamo login button to the admin login screen.
 
 Additionally `social_django` app is needed for the underlying python-social-auth.
 
@@ -75,7 +75,7 @@ Unless, of course, you wish to override the admin templates provided here.
 
 One possible gotcha is, if you've added custom views to admin without
 forwarding context from `each_context` to the your template.  Helusers
-templates except variables from `each_context` and will break if they are
+templates expect variables from `each_context` and will break if they are
 missing.
 
 ### Adding Tunnistamo authentication

--- a/helusers/admin.py
+++ b/helusers/admin.py
@@ -1,7 +1,9 @@
-from .models import ADGroupMapping
+from .models import ADGroupMapping, ADGroup
 from django.contrib import admin
 
 
 @admin.register(ADGroupMapping)
 class ADGroupMappingAdmin(admin.ModelAdmin):
     pass
+
+admin.site.register(ADGroup)


### PR DESCRIPTION
* Enables editing of AD groups, useful for testing and diagnostics
* updated README to try and clarify the purpose of two separate apps