### PR TITLE
Support different claims for AD groups & non-UUID subs

### DIFF
--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -1,3 +1,4 @@
+import logging
 import requests
 from django.utils.encoding import smart_text
 from django.utils.functional import cached_property
@@ -10,6 +11,8 @@ from rest_framework.exceptions import AuthenticationFailed
 from .authz import UserAuthorization
 from .settings import api_token_auth_settings
 from .user_utils import get_or_create_user
+
+logger = logging.getLogger(__name__)
 
 
 class ApiTokenAuthentication(JSONWebTokenAuthentication):
@@ -53,6 +56,8 @@ class ApiTokenAuthentication(JSONWebTokenAuthentication):
 
     def get_jwt_value(self, request):
         auth = get_authorization_header(request).split()
+
+        logger.debug("Authorization header: {}".format(auth))
 
         if not auth or smart_text(auth[0]).lower() != self.auth_scheme.lower():
             return None

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -38,7 +38,14 @@ class ApiTokenAuthentication(JSONWebTokenAuthentication):
         if jwt_value is None:
             return None
 
-        payload = self.decode_jwt(jwt_value)
+        try:
+            payload = self.decode_jwt(jwt_value)
+        except AuthenticationFailed as e:
+            logger.debug("Invalid token signature")
+            raise
+
+        logger.debug("Token payload decoded as: {}".format(payload))
+
         self.validate_claims(payload)
 
         user_resolver = self.settings.USER_RESOLVER  # Default: resolve_user


### PR DESCRIPTION
These changes basically allow using tokens received from Azure AD. Azure uses non-UUID style pairwise identifiers for `sub`. The path of least resistance was to convert these to UUIDs namespaced to the Tenant ID.

Also the group claim name  is not standardized, so it needed to be configurable (HELUSERS_ADGROUPS_CLAIM)

Also added lots of debugging messages, to ease testing when integrating with new token provider