### PR TITLE
Support login against Azure AD

### DIFF
--- a/helusers/defaults.py
+++ b/helusers/defaults.py
@@ -10,6 +10,9 @@ SOCIAL_AUTH_PIPELINE = (
     # the unique identifier of the given user in the provider.
     'social_core.pipeline.social_auth.social_uid',
 
+    # Ensure the UID is in UUID format and reformat it, if not.
+    'helusers.pipeline.ensure_uid_is_uuid',
+
     # Reset logged-in user if UUID differs
     'helusers.pipeline.ensure_uuid_match',
 

--- a/helusers/pipeline.py
+++ b/helusers/pipeline.py
@@ -17,9 +17,6 @@ def ensure_uid_is_uuid(details, backend, response, user=None, *args, **kwargs):
 
     uid = kwargs.get('uid')
 
-    if is_valid_uuid(uid):
-        return None
-
     # django-helusers uses UUID as the primary key for the user.
     # If the incoming token does not have UUID in the sub field,
     # we must synthesize one
@@ -29,8 +26,10 @@ def ensure_uid_is_uuid(details, backend, response, user=None, *args, **kwargs):
         # otherwise convert_to_uuid will supply a default
         namespace = backend.id_token.get('tid')
         uid = convert_to_uuid(uid, namespace)
+        return {'uid': uid}
 
-    return {'uid': uid}
+    # We did not need to change anything
+    return None
 
 def ensure_uuid_match(details, backend, response, user=None, *args, **kwargs):
     if not isinstance(backend, TunnistamoOIDCAuth):

--- a/helusers/pipeline.py
+++ b/helusers/pipeline.py
@@ -66,6 +66,9 @@ def get_username(details, backend, response, *args, **kwargs):
 
 
 def create_or_update_user(details, backend, response, user=None, *args, **kwargs):
+    # get_or_create_user is really written to deal with incoming token
+    # instead of social-auth response. Thus these mappings to try and
+    # make the response look like a parsed token
     response = response.copy()
     username = kwargs.get('username')
     uid = kwargs.get('uid')
@@ -76,6 +79,10 @@ def create_or_update_user(details, backend, response, user=None, *args, **kwargs
     # reads 'sub' from response in several places. Fix that here for now.
     if uid:
         response['sub'] = uid
+    # Pull groups from the id_token to response root.
+    # FIXME, replication with user_utils
+    group_claim_name = getattr(settings, 'HELUSERS_ADGROUPS_CLAIM', 'ad_groups')
+    response[group_claim_name] = backend.id_token.get(group_claim_name, None)
 
     user = get_or_create_user(response, oidc=True)
     return {

--- a/helusers/tunnistamo_oidc.py
+++ b/helusers/tunnistamo_oidc.py
@@ -15,6 +15,17 @@ class TunnistamoOIDCAuth(OpenIdConnectAuth):
         # Allow OIDC endpoint to be overridden through local settings
         self.OIDC_ENDPOINT = self.setting('OIDC_ENDPOINT', self.OIDC_ENDPOINT)
 
+    # Workaround for the cases where jwks-endpoint does not specify
+    # alg for keys. Default to RS256 per:
+    # https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+    def get_remote_jwks_keys(self):
+        keys = super().get_remote_jwks_keys()
+        for key in keys:
+            if 'alg' not in key:
+                key['alg'] = 'RS256'
+
+        return keys 
+
     def get_end_session_url(self, request, id_token):
         url = self.END_SESSION_URL or \
             self.oidc_config().get('end_session_endpoint')

--- a/helusers/tunnistamo_oidc.py
+++ b/helusers/tunnistamo_oidc.py
@@ -40,7 +40,13 @@ class TunnistamoOIDCAuth(OpenIdConnectAuth):
         url = self.END_SESSION_URL or \
             self.oidc_config().get('end_session_endpoint')
 
-        params = dict(id_token_hint=id_token)
+        params = {}
+
+        # Sadly Azure AD does not like having ID token included
+        # in end_session request. Allow configuring the inclusion.
+        if self.setting('ID_TOKEN_IN_END_SESSION', True):
+            params = dict(id_token_hint=id_token)
+
         try:
             post_logout_url = reverse('helusers:auth_logout_complete')
         except NoReverseMatch:

--- a/helusers/tunnistamo_oidc.py
+++ b/helusers/tunnistamo_oidc.py
@@ -1,8 +1,11 @@
+import logging
 import urllib.parse as urlparse
 
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
+
+logger = logging.getLogger(__name__)
 
 
 class TunnistamoOIDCAuth(OpenIdConnectAuth):
@@ -25,6 +28,13 @@ class TunnistamoOIDCAuth(OpenIdConnectAuth):
                 key['alg'] = 'RS256'
 
         return keys 
+
+    # Override for logging
+    def request_access_token(self, *args, **kwargs):
+        response = super().request_access_token(*args, **kwargs)
+        logger.debug(f"Token response: {response}")
+
+        return response
 
     def get_end_session_url(self, request, id_token):
         url = self.END_SESSION_URL or \

--- a/helusers/user_utils.py
+++ b/helusers/user_utils.py
@@ -115,7 +115,7 @@ def get_or_create_user(payload, oidc=False):
     if not is_valid_uuid(user_id):
         # Maybe we have an Azure pairwise ID? Check for Azure tenant ID
         # in token and use that as UUID namespace if available
-        namespace = UUID(payload.get('tid'))
+        namespace = payload.get('tid')
         user_id = convert_to_uuid(user_id, namespace)
 
     try_again = False


### PR DESCRIPTION
Azure AD uses alphanumeric pairwise identifiers for users, while Django-helusers always expects to use UUID:s. This PR maps them to UUIDs, thus allowing AD issued tokens to be accepted.

Also:
* handle jwk endpoints that do not specify algorithm for keys by defaulting to RS256 (this is spec compliant)
* Azure AD does not like to have id_token_hint included in logout request. Create a setting for disabling that.