### PR TITLE
Add Python versions 3.7-3.9 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ dist: focal
 language: python
 python:
   - '3.6'
+  - '3.7'
+  - '3.8'
+  - '3.9'
 
 cache: pip
 


### PR DESCRIPTION
Let's cover more Python versions with automated testing.