### PR TITLE
Always use UUID type for User's uuid field

### DIFF
--- a/helusers/tests/test_oidc_api_token_authentication.py
+++ b/helusers/tests/test_oidc_api_token_authentication.py
@@ -1,5 +1,6 @@
 import json
 import time
+import uuid
 
 import pytest
 from jose import jwt
@@ -8,8 +9,8 @@ from helusers.oidc import ApiTokenAuthentication
 
 from .keys import rsa_key
 
-
 ISSUER = "test_issuer"
+
 
 class _TestableApiTokenAuthentication(ApiTokenAuthentication):
     @property
@@ -28,13 +29,13 @@ def test_valid_jwt_is_accepted(rf):
 
     unix_timestamp_now = int(time.time())
 
-    user_uuid = "b7a35517-eb1f-46c9-88bf-3206fb659c3c"
+    user_uuid = uuid.UUID("b7a35517-eb1f-46c9-88bf-3206fb659c3c")
     jwt_data = {
         "iss": ISSUER,
         "aud": "test_audience",
         "iat": unix_timestamp_now - 10,
         "exp": unix_timestamp_now + 1000,
-        "sub": user_uuid,
+        "sub": str(user_uuid),
     }
 
     encoded_jwt = jwt.encode(

--- a/helusers/tests/test_user_utils.py
+++ b/helusers/tests/test_user_utils.py
@@ -1,0 +1,20 @@
+import uuid
+
+import pytest
+
+from helusers.user_utils import get_or_create_user
+
+
+@pytest.mark.django_db
+def test_get_or_create_user_always_returns_a_User_with_UUID_type_id():
+    user_uuid = uuid.uuid4()
+    payload = {
+        "sub": str(user_uuid),
+    }
+
+    user1 = get_or_create_user(payload)
+    user2 = get_or_create_user(payload)
+
+    assert user1.uuid == user_uuid
+    assert user2.uuid == user_uuid
+    assert user1 == user2

--- a/helusers/user_utils.py
+++ b/helusers/user_utils.py
@@ -67,6 +67,7 @@ def update_user(user, payload, oidc=False):
 # for a new user, the first requests fired toward the API will race
 # for creating the user. All but one of these will then fail.
 def _try_create_or_update(user_id, payload, oidc):
+    user_id = UUID(user_id)
     user_model = get_user_model()
     with transaction.atomic():
         try:


### PR DESCRIPTION
The `user_utils.get_or_create_user` helper returned a `User` having the `uuid` field of type `str` or `UUID`, depending on whether the `User` got created (`uuid` of type `str`) or did it pre-exist (`uuid` of type `UUID`). Now the `uuid` field is always of type `UUID`.