### PR TITLE
JWT authenticator class without DRF dependency

### DIFF
--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -5,7 +5,10 @@ try:
 except ImportError:
     pass
 
+from django.utils.functional import cached_property
 from jose import jwt
+
+from .settings import api_token_auth_settings
 
 
 class JWT:
@@ -36,3 +39,23 @@ class JWT:
         if not hasattr(self, "_claims"):
             self._claims = jwt.get_unverified_claims(self._encoded_jwt)
         return self._claims
+
+    def has_api_scope_with_prefix(self, prefix):
+        """Checks if there is an API scope with the given prefix.
+        The name of the claims field where API scopes are looked for is
+        determined by the OIDC_API_TOKEN_AUTH['API_AUTHORIZATION_FIELD']
+        setting."""
+        return any(
+            x == prefix or x.startswith(prefix + ".")
+            for x in self._authorized_api_scopes
+        )
+
+    @cached_property
+    def _authorized_api_scopes(self):
+        def is_list_of_non_empty_strings(value):
+            return isinstance(value, list) and all(
+                isinstance(x, str) and x for x in value
+            )
+
+        api_scopes = self.claims.get(api_token_auth_settings.API_AUTHORIZATION_FIELD)
+        return set(api_scopes) if is_list_of_non_empty_strings(api_scopes) else set()

--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -4,3 +4,15 @@ try:
                                            patch_jwt_settings)
 except ImportError:
     pass
+
+from jose import jwt
+
+
+class JWT:
+    def __init__(self, encoded_jwt):
+        self._encoded_jwt = encoded_jwt
+
+    @property
+    def claims(self):
+        """Returns all the claims of the JWT as a dictionary."""
+        return jwt.get_unverified_claims(self._encoded_jwt)

--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -13,7 +13,11 @@ from .settings import api_token_auth_settings
 
 class JWT:
     def __init__(self, encoded_jwt):
+        """The constructor checks that a JWT can be extracted from the
+        provided input but it doesn't validate it in any way. If the
+        input is invalid, an exception is raised."""
         self._encoded_jwt = encoded_jwt
+        self._claims = jwt.get_unverified_claims(encoded_jwt)
 
     def validate(self, keys, audience):
         """Verifies the JWT's signature using the provided keys,
@@ -24,7 +28,7 @@ class JWT:
             "require_exp": True,
         }
 
-        self._claims = jwt.decode(
+        jwt.decode(
             self._encoded_jwt, keys, options=options, audience=audience
         )
 
@@ -36,8 +40,6 @@ class JWT:
     @property
     def claims(self):
         """Returns all the claims of the JWT as a dictionary."""
-        if not hasattr(self, "_claims"):
-            self._claims = jwt.get_unverified_claims(self._encoded_jwt)
         return self._claims
 
     def has_api_scope_with_prefix(self, prefix):

--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -18,6 +18,7 @@ class JWT:
 
         options = {
             "require_aud": True,
+            "require_exp": True,
         }
 
         self._claims = jwt.decode(

--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -12,10 +12,17 @@ class JWT:
     def __init__(self, encoded_jwt):
         self._encoded_jwt = encoded_jwt
 
-    def validate(self, keys):
+    def validate(self, keys, audience):
         """Verifies the JWT's signature using the provided keys,
         and validates the claims, raising an exception if anything fails."""
-        self._claims = jwt.decode(self._encoded_jwt, keys)
+
+        options = {
+            "require_aud": True,
+        }
+
+        self._claims = jwt.decode(
+            self._encoded_jwt, keys, options=options, audience=audience
+        )
 
     @property
     def issuer(self):

--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -12,7 +12,19 @@ class JWT:
     def __init__(self, encoded_jwt):
         self._encoded_jwt = encoded_jwt
 
+    def validate(self, keys):
+        """Verifies the JWT's signature using the provided keys,
+        and validates the claims, raising an exception if anything fails."""
+        self._claims = jwt.decode(self._encoded_jwt, keys)
+
+    @property
+    def issuer(self):
+        """Returns the "iss" claim value."""
+        return self.claims["iss"]
+
     @property
     def claims(self):
         """Returns all the claims of the JWT as a dictionary."""
-        return jwt.get_unverified_claims(self._encoded_jwt)
+        if not hasattr(self, "_claims"):
+            self._claims = jwt.get_unverified_claims(self._encoded_jwt)
+        return self._claims

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -4,6 +4,7 @@ except ImportError:
     pass
 
 
+import requests
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
 
@@ -11,6 +12,18 @@ from .authz import UserAuthorization
 from .jwt import JWT
 from .settings import api_token_auth_settings
 from .user_utils import get_or_create_user
+
+
+class OIDCConfig:
+    def __init__(self, issuer):
+        self._issuer = issuer
+
+    def keys(self):
+        config_url = self._issuer + "/.well-known/openid-configuration"
+        config = requests.get(config_url).json()
+
+        keys_url = config["jwks_uri"]
+        return requests.get(keys_url).json()
 
 
 def _build_defaults():

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -107,6 +107,13 @@ class RequestJWTAuthentication:
         except Exception:
             raise AuthenticationError("JWT verification failed.")
 
+        if api_token_auth_settings.REQUIRE_API_SCOPE_FOR_AUTHENTICATION:
+            api_scope = api_token_auth_settings.API_SCOPE_PREFIX
+            if not jwt.has_api_scope_with_prefix(api_scope):
+                raise AuthenticationError(
+                    'Not authorized for API scope "{}"'.format(api_scope)
+                )
+
         claims = jwt.claims
         user = get_or_create_user(claims, oidc=True)
         auth = UserAuthorization(user, claims)

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -94,6 +94,8 @@ class RequestJWTAuthentication:
         try:
             auth_header = request.headers["Authorization"]
             auth_scheme, jwt_value = auth_header.split()
+            if auth_scheme != "Bearer":
+                return None
             jwt = JWT(jwt_value)
         except Exception:
             return None

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -2,3 +2,26 @@ try:
     from ._oidc_auth_impl import ApiTokenAuthentication, resolve_user
 except ImportError:
     pass
+
+
+from .authz import UserAuthorization
+from .jwt import JWT
+from .user_utils import get_or_create_user
+
+
+class RequestJWTAuthentication:
+    def authenticate(self, request):
+        """Looks for a JWT from the request's "Authorization" header and verifies it.
+        If verification passes, takes a user's id from the JWT's "sub" claim.
+        Creates a User if it doesn't already exist. On success returns the User
+        and a UserAuthorization object as a (User, UserAuthorization) tuple."""
+        auth = request.headers["Authorization"].split()
+        jwt_value = auth[1]
+
+        jwt = JWT(jwt_value)
+
+        claims = jwt.claims
+        user = get_or_create_user(claims, oidc=True)
+        auth = UserAuthorization(user, claims)
+
+        return (user, auth)

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -83,12 +83,19 @@ class RequestJWTAuthentication:
         self._key_provider = key_provider or _defaults.key_provider
 
     def authenticate(self, request):
-        """Looks for a JWT from the request's "Authorization" header and verifies it.
+        """Looks for a JWT from the request's "Authorization" header. If the header
+        is not found, returns None.
+
+        If the header is found and contains a JWT then the JWT gets verified.
         If verification passes, takes a user's id from the JWT's "sub" claim.
         Creates a User if it doesn't already exist. On success returns the User
         and a UserAuthorization object as a (User, UserAuthorization) tuple.
         Raises an AuthenticationError on authentication failure."""
-        auth = request.headers["Authorization"].split()
+        try:
+            auth = request.headers["Authorization"].split()
+        except KeyError:
+            return None
+
         jwt_value = auth[1]
 
         jwt = JWT(jwt_value)

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -84,7 +84,7 @@ class RequestJWTAuthentication:
 
     def authenticate(self, request):
         """Looks for a JWT from the request's "Authorization" header. If the header
-        is not found, returns None.
+        is not found, or it doesn't contain a JWT, returns None.
 
         If the header is found and contains a JWT then the JWT gets verified.
         If verification passes, takes a user's id from the JWT's "sub" claim.
@@ -92,13 +92,11 @@ class RequestJWTAuthentication:
         and a UserAuthorization object as a (User, UserAuthorization) tuple.
         Raises an AuthenticationError on authentication failure."""
         try:
-            auth = request.headers["Authorization"].split()
-        except KeyError:
+            auth_header = request.headers["Authorization"]
+            auth_scheme, jwt_value = auth_header.split()
+            jwt = JWT(jwt_value)
+        except Exception:
             return None
-
-        jwt_value = auth[1]
-
-        jwt = JWT(jwt_value)
 
         try:
             issuer = jwt.issuer

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -9,16 +9,32 @@ from .jwt import JWT
 from .user_utils import get_or_create_user
 
 
+class AuthenticationError(Exception):
+    pass
+
+
 class RequestJWTAuthentication:
+    def __init__(self, key_provider=None):
+        """
+        key_provider: a callable that provides public keys for an issuer.
+        """
+        self._key_provider = key_provider
+
     def authenticate(self, request):
         """Looks for a JWT from the request's "Authorization" header and verifies it.
         If verification passes, takes a user's id from the JWT's "sub" claim.
         Creates a User if it doesn't already exist. On success returns the User
-        and a UserAuthorization object as a (User, UserAuthorization) tuple."""
+        and a UserAuthorization object as a (User, UserAuthorization) tuple.
+        Raises an AuthenticationError on authentication failure."""
         auth = request.headers["Authorization"].split()
         jwt_value = auth[1]
 
         jwt = JWT(jwt_value)
+        keys = self._key_provider(jwt.issuer)
+        try:
+            jwt.validate(keys)
+        except Exception:
+            raise AuthenticationError("JWT verification failed.")
 
         claims = jwt.claims
         user = get_or_create_user(claims, oidc=True)

--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -16,6 +16,14 @@ from .user_utils import get_or_create_user
 def _build_defaults():
     class _Defaults:
         @cached_property
+        def audience(self):
+            if not api_token_auth_settings.AUDIENCE:
+                raise ImproperlyConfigured(
+                    "You must set OIDC_API_TOKEN_AUTH['AUDIENCE'] setting to the accepted JWT audience."
+                )
+            return api_token_auth_settings.AUDIENCE
+
+        @cached_property
         def issuers(self):
             issuers = api_token_auth_settings.ISSUER
             if not issuers:
@@ -64,7 +72,7 @@ class RequestJWTAuthentication:
 
         keys = self._key_provider(issuer)
         try:
-            jwt.validate(keys)
+            jwt.validate(keys, _defaults.audience)
         except Exception:
             raise AuthenticationError("JWT verification failed.")
 

--- a/helusers/tests/conftest.py
+++ b/helusers/tests/conftest.py
@@ -1,6 +1,13 @@
 from datetime import datetime, timezone
 
 import pytest
+import responses
+
+
+@pytest.fixture
+def mock_responses():
+    with responses.RequestsMock() as mock_resps:
+        yield mock_resps
 
 
 def unix_timestamp_now():

--- a/helusers/tests/conftest.py
+++ b/helusers/tests/conftest.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timezone
+
+import pytest
+
+
+def unix_timestamp_now():
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    return int((datetime.now(tz=timezone.utc) - epoch).total_seconds())
+
+
+@pytest.fixture(name="unix_timestamp_now")
+def unix_timestamp_now_fixture():
+    return unix_timestamp_now()

--- a/helusers/tests/keys.py
+++ b/helusers/tests/keys.py
@@ -2,10 +2,21 @@ from jose import jwk
 from jose.constants import ALGORITHMS
 
 
-class rsa_key:
-    jose_algorithm = ALGORITHMS.RS256
+def _build_key(private_pem, public_pem):
+    class _Key:
+        pass
 
-    private_key_pem = """-----BEGIN PRIVATE KEY-----
+    key = _Key()
+    key.jose_algorithm = ALGORITHMS.RS256
+    key.private_key_pem = private_pem
+    key.public_key_pem = public_pem
+    key.public_key_jwk = jwk.construct(public_pem, key.jose_algorithm).to_dict()
+
+    return key
+
+
+rsa_key = _build_key(
+    """-----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDUeT3OFPatye6I
 tmArvjR+f0lZu4QEOxtGxHj1UWzLiUbONygTrWCVXh5OFaH+GFPOfqax2iJSWc+7
 6JYy2y2XxdG1Tehcvpsv/gKqRJG2afVKY+qCCmtRwksWan4kRU6F9UKDHJl6emkE
@@ -32,9 +43,8 @@ cdFYNk9B+gJ8YoGlRKtGk3vvoRTDTDx+Ntnlib6xjbCWk2MShDVPqkJqgL6ZTlP4
 6Po5IhRvBAiNJg/N7mirkdb7NyB6I4aA1ztoimizDrJPn7edVKUTluNw2Fk3QsLS
 va0XlEJu3URaqHLcKi6J74dlSt+3W4pSTJF7eseyFMI64bWSEho1tvChLSCq6lUE
 zyIWjEHazLOEdBArFsgWsg==
------END PRIVATE KEY-----"""
-
-    public_key_pem = """-----BEGIN PUBLIC KEY-----
+-----END PRIVATE KEY-----""",
+    """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Hk9zhT2rcnuiLZgK740
 fn9JWbuEBDsbRsR49VFsy4lGzjcoE61glV4eThWh/hhTzn6msdoiUlnPu+iWMtst
 l8XRtU3oXL6bL/4CqkSRtmn1SmPqggprUcJLFmp+JEVOhfVCgxyZenppBHvcQP/g
@@ -42,6 +52,46 @@ l8XRtU3oXL6bL/4CqkSRtmn1SmPqggprUcJLFmp+JEVOhfVCgxyZenppBHvcQP/g
 9qGcoNEJZ1NrU3GTBtg9e9sBccjPIxn8ux5vF/jEB+Tf2hXim+3/+nkwO+GuYVuZ
 3EU2rGh+XYwnARUsgGkvBeFAmWLEXbYdZaeJwYvfOg2y9bmlW7plNjqOhWvyt7hk
 RQIDAQAB
------END PUBLIC KEY-----"""
+-----END PUBLIC KEY-----""",
+)
 
-    public_key_jwk = jwk.construct(public_key_pem, jose_algorithm).to_dict()
+
+rsa_key2 = _build_key(
+    """-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDOzPIvae8JdGmY
+W17EkdzLQ+pURgkN891RHWDy/6FeZSwxK6bVmhq76tHcGOM4S7mMs0XIt5BGFUkp
+yool4HymqD8F+sbi0mxRNYh435lGKNscl83BQgl+VsEDUSGKlMc4A3KIU2E1DeMl
+WuTU7Y8IjgKMtbLELC/YZwpEHeZKYtRM8Q25JNaPvO0963dw/2FU+JUQft8FG4GN
+ThWd7dCTeAfDWz+/CM8IlX6LLIjqePOcBd/nmfDJMK7sFpIJ+pT9mCSXIOd7hL4h
+zyP8z8fJhv2OyOopUvBWFI/QIDQFhmQsOb3YE731F1pMjjSXM+VMdY86BfMFvtbN
+JbPGzpErAgMBAAECggEAIbDn/+t9QwgRL/4qyVGOLBtrcMFcNka1lsJ3if81lgBb
+m8Ml0gTiOB1AhWAUnJZRq2eFhfbJ7XEIU2Oo8BTLmgctBVde0ZNAjFZxXmfnO7Pq
+RpVAsyyECW4u0dCE62PjtO9y2FzlKFST3gEZ6MqvE9C2/5+WeTlNri7TUFeirhly
+qpx7wqC5HRFPyJRQCDybIwd9jVPWAzVF4LMobVZDgfR1dlQsGa0n5VqVHuBxOYFO
+ZEbicCHIaUCvF4STGnkvOV/FwGz6D9FtaBvZ1A3Fx4pGGKRoxGKnTAxaqqTBR6sJ
+wJC88nH3M3kI33Mn7V35ad3SgRJqjZbNTa41s+MHiQKBgQD0jyexBoZsZJD0xvlB
+Xx3R5r1e+tZbqxWZyi+bHxspsFW1OQiqBoaC32W//c1aaCCJzLCXci01AMOAefxE
+OIJCxTtNjR9nbpDCTC0VExv4CnPtAPjb5FN1PxvX6YAMeYgXwDTYJBdEQVCMex/E
+emsE2zQlzsAziETPmhW+WpjNvQKBgQDYeZfRMr01BGQgs0T24LzFXPP2W9Q278Zv
+zppjLZjS2vuXBehbgj5PRAFKOtqvAH+YBevvmbJAziF0W23AkeaS2SCC7H85Ayin
+wlNYEX1K1exNjYlvMEWe2KPrWucgp8ZZwzX9SrTROx6rqd547GDAOLBLpHV+qCWV
+okc9bDFFBwKBgQC3wKBYGMkDxIROBvrdrXQgdLixFtPdSK0QQqSGb1bfegjMA7CI
+4CJNT0GKgk67sSVRpKTDBh0FiC9c50sujy8AsGUgnfqMorzN4KK3BQas1l3IJETY
+I7S5kdN/5Yg61030WozaIjQBKvo0s4ZpAHpMyc9i4Pf1QFxDiEjyH+xUGQKBgFNI
+xK4JtV22aMdj8T6CTF4qWvoHbmgMa+4MML3Dhy5oba826KR8QXjBkzV52zTFHlHg
+xVsTaM8h/yEDJACYoXsR6j40uuW2X2fbjbEuWWP3VciokZ2jlsV8V+RuvsmDgv55
+6kWe/l4ZPr2QxzUCzF5n8PvJNCMckgk1u+7Xt0T1AoGBANWQD9ukbEXDGzvN84zd
+3Yf4aHtxg0IMEoUmgsYemhZp7PkBNS0CKkXg6ZedJLq6Q1yOHIxMT7N+y2V7S99Z
+0uBTKAQn5oaj/WU7tCYEdnqc7jAzWvhVKT2MvvxkxeWNHAGKnxzsj+uape6nDTAw
+y5RDdDKjlM1hcSqn31RhjRml
+-----END PRIVATE KEY-----""",
+    """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzszyL2nvCXRpmFtexJHc
+y0PqVEYJDfPdUR1g8v+hXmUsMSum1Zoau+rR3BjjOEu5jLNFyLeQRhVJKcqKJeB8
+pqg/BfrG4tJsUTWIeN+ZRijbHJfNwUIJflbBA1EhipTHOANyiFNhNQ3jJVrk1O2P
+CI4CjLWyxCwv2GcKRB3mSmLUTPENuSTWj7ztPet3cP9hVPiVEH7fBRuBjU4Vne3Q
+k3gHw1s/vwjPCJV+iyyI6njznAXf55nwyTCu7BaSCfqU/ZgklyDne4S+Ic8j/M/H
+yYb9jsjqKVLwVhSP0CA0BYZkLDm92BO99RdaTI40lzPlTHWPOgXzBb7WzSWzxs6R
+KwIDAQAB
+-----END PUBLIC KEY-----""",
+)

--- a/helusers/tests/settings.py
+++ b/helusers/tests/settings.py
@@ -14,4 +14,5 @@ AUTH_USER_MODEL = "tests.User"
 
 OIDC_API_TOKEN_AUTH = {
     "AUDIENCE": "test_audience",
+    "ISSUER": ["https://test_issuer_1", "https://test_issuer_2"]
 }

--- a/helusers/tests/settings.py
+++ b/helusers/tests/settings.py
@@ -14,5 +14,8 @@ AUTH_USER_MODEL = "tests.User"
 
 OIDC_API_TOKEN_AUTH = {
     "AUDIENCE": "test_audience",
-    "ISSUER": ["https://test_issuer_1", "https://test_issuer_2"]
+    "ISSUER": ["https://test_issuer_1", "https://test_issuer_2"],
+    "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": False,
+    "API_AUTHORIZATION_FIELD": "",
+    "API_SCOPE_PREFIX": "",
 }

--- a/helusers/tests/test_oidc_oidc_config.py
+++ b/helusers/tests/test_oidc_oidc_config.py
@@ -1,0 +1,33 @@
+from helusers.oidc import OIDCConfig
+
+ISSUER = "https://test_issuer"
+CONFIG_URL = f"{ISSUER}/.well-known/openid-configuration"
+JWKS_URL = f"{ISSUER}/jwks"
+
+# This isn't a full OIDC configuration object. It contains only parts relevant for the tests.
+CONFIGURATION = {
+    "jwks_uri": JWKS_URL,
+}
+
+# The key data in this object isn't valid.
+KEYS = {
+    "keys": [
+        {
+            "kty": "RSA",
+            "alg": "RS256",
+            "use": "sig",
+            "kid": "12345",
+            "n": "mMg6h8eUyc7G",
+            "e": "AQAB",
+        }
+    ]
+}
+
+
+def test_keys_are_returned(mock_responses):
+    mock_responses.add(method="GET", url=CONFIG_URL, json=CONFIGURATION)
+    mock_responses.add(method="GET", url=JWKS_URL, json=KEYS)
+
+    config = OIDCConfig(ISSUER)
+
+    assert config.keys() == KEYS

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -194,3 +194,11 @@ class TestApiScopeChecking:
 def test_if_authorization_header_is_missing_returns_none(rf):
     request = rf.get("/path")
     assert RequestJWTAuthentication().authenticate(request) is None
+
+
+@pytest.mark.parametrize(
+    "auth", ["TooShort", "Unknown scheme", "Bearer not_a_jwt", "Too many parts"]
+)
+def test_if_authorization_header_does_not_contain_a_jwt_returns_none(rf, auth):
+    request = rf.get("/path", HTTP_AUTHORIZATION=auth)
+    assert RequestJWTAuthentication().authenticate(request) is None

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -189,3 +189,8 @@ class TestApiScopeChecking:
     ):
         self.enable_api_scope_checking(settings)
         authentication_does_not_pass(authorization=["another_api_scope"])
+
+
+def test_if_authorization_header_is_missing_returns_none(rf):
+    request = rf.get("/path")
+    assert RequestJWTAuthentication().authenticate(request) is None

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -10,13 +10,14 @@ from helusers.settings import api_token_auth_settings
 from .keys import rsa_key, rsa_key2
 
 ISSUER = api_token_auth_settings.ISSUER[0]
+AUDIENCE = api_token_auth_settings.AUDIENCE
 
 
 def public_key_provider(issuer):
     return [rsa_key.public_key_jwk]
 
 
-def do_authentication(issuer=ISSUER, signing_key=rsa_key):
+def do_authentication(issuer=ISSUER, audience=AUDIENCE, signing_key=rsa_key):
     sut = RequestJWTAuthentication(key_provider=public_key_provider)
 
     user_uuid = uuid.UUID("b7a35517-eb1f-46c9-88bf-3206fb659c3c")
@@ -26,6 +27,9 @@ def do_authentication(issuer=ISSUER, signing_key=rsa_key):
 
     if issuer:
         jwt_data["iss"] = issuer
+
+    if audience:
+        jwt_data["aud"] = audience
 
     encoded_jwt = jwt.encode(
         jwt_data, key=signing_key.private_key_pem, algorithm=rsa_key.jose_algorithm
@@ -73,3 +77,16 @@ def test_any_issuer_from_settings_is_accepted(issuer):
 
 def test_issuer_not_found_from_settings_is_not_accepted():
     authentication_does_not_pass(issuer="unknown_issuer")
+
+
+def test_audience_is_required():
+    authentication_does_not_pass(audience=None)
+
+
+@pytest.mark.django_db
+def test_audience_from_settings_is_accepted():
+    authentication_passes(audience=AUDIENCE)
+
+
+def test_audience_not_found_from_settings_is_not_accepted():
+    authentication_does_not_pass(audience="unknown_audience")

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -1,0 +1,29 @@
+import uuid
+
+import pytest
+from jose import jwt
+
+from helusers.oidc import RequestJWTAuthentication
+
+from .keys import rsa_key
+
+
+@pytest.mark.django_db
+def test_valid_jwt_is_accepted(rf):
+    sut = RequestJWTAuthentication()
+
+    user_uuid = uuid.UUID("b7a35517-eb1f-46c9-88bf-3206fb659c3c")
+    jwt_data = {
+        "sub": str(user_uuid),
+    }
+
+    encoded_jwt = jwt.encode(
+        jwt_data, key=rsa_key.private_key_pem, algorithm=rsa_key.jose_algorithm
+    )
+
+    request = rf.get("/path", HTTP_AUTHORIZATION=f"Bearer {encoded_jwt}")
+
+    (user, auth) = sut.authenticate(request)
+
+    assert user.uuid == user_uuid
+    assert auth.user == user

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -1,29 +1,52 @@
 import uuid
 
 import pytest
+from django.test.client import RequestFactory
 from jose import jwt
 
-from helusers.oidc import RequestJWTAuthentication
+from helusers.oidc import AuthenticationError, RequestJWTAuthentication
 
-from .keys import rsa_key
+from .keys import rsa_key, rsa_key2
+
+def public_key_provider(issuer):
+    return [rsa_key.public_key_jwk]
 
 
-@pytest.mark.django_db
-def test_valid_jwt_is_accepted(rf):
-    sut = RequestJWTAuthentication()
+def do_authentication(signing_key=rsa_key):
+    sut = RequestJWTAuthentication(key_provider=public_key_provider)
 
     user_uuid = uuid.UUID("b7a35517-eb1f-46c9-88bf-3206fb659c3c")
     jwt_data = {
         "sub": str(user_uuid),
+        "iss": "issuer",
     }
 
     encoded_jwt = jwt.encode(
-        jwt_data, key=rsa_key.private_key_pem, algorithm=rsa_key.jose_algorithm
+        jwt_data, key=signing_key.private_key_pem, algorithm=rsa_key.jose_algorithm
     )
 
+    rf = RequestFactory()
     request = rf.get("/path", HTTP_AUTHORIZATION=f"Bearer {encoded_jwt}")
 
     (user, auth) = sut.authenticate(request)
 
     assert user.uuid == user_uuid
     assert auth.user == user
+
+
+def authentication_passes():
+    do_authentication()
+
+
+def authentication_does_not_pass(**kwargs):
+    with pytest.raises(AuthenticationError):
+        do_authentication(**kwargs)
+
+
+@pytest.mark.django_db
+def test_valid_jwt_is_accepted():
+    authentication_passes()
+
+
+def test_invalid_signature_is_not_accepted():
+    authentication_does_not_pass(signing_key=rsa_key2)

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -5,21 +5,27 @@ from django.test.client import RequestFactory
 from jose import jwt
 
 from helusers.oidc import AuthenticationError, RequestJWTAuthentication
+from helusers.settings import api_token_auth_settings
 
 from .keys import rsa_key, rsa_key2
+
+ISSUER = api_token_auth_settings.ISSUER[0]
+
 
 def public_key_provider(issuer):
     return [rsa_key.public_key_jwk]
 
 
-def do_authentication(signing_key=rsa_key):
+def do_authentication(issuer=ISSUER, signing_key=rsa_key):
     sut = RequestJWTAuthentication(key_provider=public_key_provider)
 
     user_uuid = uuid.UUID("b7a35517-eb1f-46c9-88bf-3206fb659c3c")
     jwt_data = {
         "sub": str(user_uuid),
-        "iss": "issuer",
     }
+
+    if issuer:
+        jwt_data["iss"] = issuer
 
     encoded_jwt = jwt.encode(
         jwt_data, key=signing_key.private_key_pem, algorithm=rsa_key.jose_algorithm
@@ -34,8 +40,8 @@ def do_authentication(signing_key=rsa_key):
     assert auth.user == user
 
 
-def authentication_passes():
-    do_authentication()
+def authentication_passes(**kwargs):
+    do_authentication(**kwargs)
 
 
 def authentication_does_not_pass(**kwargs):
@@ -50,3 +56,20 @@ def test_valid_jwt_is_accepted():
 
 def test_invalid_signature_is_not_accepted():
     authentication_does_not_pass(signing_key=rsa_key2)
+
+
+def test_issuer_is_required():
+    authentication_does_not_pass(issuer=None)
+
+
+@pytest.mark.parametrize(
+    "issuer",
+    api_token_auth_settings.ISSUER,
+)
+@pytest.mark.django_db
+def test_any_issuer_from_settings_is_accepted(issuer):
+    authentication_passes(issuer=issuer)
+
+
+def test_issuer_not_found_from_settings_is_not_accepted():
+    authentication_does_not_pass(issuer="unknown_issuer")

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,3 +2,4 @@ django-allauth
 drf-oidc-auth
 pytest
 pytest-django
+responses

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,8 +30,9 @@ pytest==6.1.1             # via -r requirements-dev.in, pytest-django
 python3-openid==3.2.0     # via django-allauth
 pytz==2020.1              # via django
 requests-oauthlib==1.3.0  # via django-allauth
-requests==2.24.0          # via django-allauth, drf-oidc-auth, requests-oauthlib
-six==1.15.0               # via cryptography, packaging
+requests==2.24.0          # via django-allauth, drf-oidc-auth, requests-oauthlib, responses
+responses==0.12.1         # via -r requirements-dev.in
+six==1.15.0               # via cryptography, packaging, responses
 sqlparse==0.4.1           # via django
 toml==0.10.1              # via pytest
-urllib3==1.25.11          # via requests
+urllib3==1.25.11          # via requests, responses


### PR DESCRIPTION
A new authenticator/JWT validation service, without opinions about where it's used (with Django REST Framework or any other). It just takes in a Django `HTTPRequest`, extracts a JWT from the "Authorization" header and validates that JWT. If validation succeeds, constructs/updates a `User` (just like the other authenticators in `django-helusers`), ~puts that `User` into the request as `request.user` and puts a `UserAuthorization` object into `request.auth`~ and returns that `User` together with a `UserAuthorization` object.

This PR contains some rough edges still (and those could be honed in other PRs if this is already big enough). For example the `OIDCConfig` class should cache the OIDC configuration and keys it fetches from an authorization server.

HP-182