### PR TITLE
HP-182 multiple accepted audiences

### DIFF
--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -7,6 +7,8 @@ except ImportError:
 import requests
 from cachetools.func import ttl_cache
 from django.core.exceptions import ImproperlyConfigured
+from django.core.signals import setting_changed
+from django.dispatch import receiver
 from django.utils.functional import cached_property
 
 from .authz import UserAuthorization
@@ -69,6 +71,13 @@ def _build_defaults():
 
 
 _defaults = _build_defaults()
+
+
+@receiver(setting_changed)
+def _reload_settings(setting, **kwargs):
+    if setting == "OIDC_API_TOKEN_AUTH":
+        global _defaults
+        _defaults = _build_defaults()
 
 
 class AuthenticationError(Exception):

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -15,6 +15,12 @@ AUDIENCE = api_token_auth_settings.AUDIENCE
 USER_UUID = uuid.UUID("b7a35517-eb1f-46c9-88bf-3206fb659c3c")
 
 
+def update_oidc_settings(settings, updates):
+    oidc_settings = settings.OIDC_API_TOKEN_AUTH.copy()
+    oidc_settings.update(updates)
+    settings.OIDC_API_TOKEN_AUTH = oidc_settings
+
+
 def public_key_provider(issuer):
     return [rsa_key.public_key_jwk]
 
@@ -168,11 +174,14 @@ def test_default_key_provider_fetches_keys_from_issuer_server(mock_responses):
 class TestApiScopeChecking:
     @staticmethod
     def enable_api_scope_checking(settings):
-        oidc_settings = settings.OIDC_API_TOKEN_AUTH.copy()
-        oidc_settings["REQUIRE_API_SCOPE_FOR_AUTHENTICATION"] = True
-        oidc_settings["API_AUTHORIZATION_FIELD"] = "authorization"
-        oidc_settings["API_SCOPE_PREFIX"] = "api_scope"
-        settings.OIDC_API_TOKEN_AUTH = oidc_settings
+        update_oidc_settings(
+            settings,
+            {
+                "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": True,
+                "API_AUTHORIZATION_FIELD": "authorization",
+                "API_SCOPE_PREFIX": "api_scope",
+            },
+        )
 
     @pytest.mark.django_db
     def test_if_required_api_scope_is_found_as_is_then_authentication_passes(

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -110,6 +110,13 @@ def test_audience_from_settings_is_accepted():
     authentication_passes(audience=AUDIENCE)
 
 
+@pytest.mark.django_db
+def test_audience_in_token_can_be_a_list():
+    authentication_passes(audience=["some_audience", AUDIENCE, "another_audience"])
+
+    authentication_does_not_pass(audience=["some_audience", "another_audience"])
+
+
 def test_audience_not_found_from_settings_is_not_accepted():
     authentication_does_not_pass(audience="unknown_audience")
 

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -127,6 +127,24 @@ def test_audience_not_found_from_settings_is_not_accepted():
     authentication_does_not_pass(audience="unknown_audience")
 
 
+@pytest.mark.django_db
+def test_audiences_setting_can_be_multi_valued(settings):
+    audiences = ["test_audience1", "test_audience2"]
+
+    update_oidc_settings(
+        settings,
+        {
+            "AUDIENCE": audiences,
+        },
+    )
+
+    for audience in audiences:
+        authentication_passes(audience=audience)
+        authentication_passes(audience=["some_audience", audience, "another_audience"])
+
+    authentication_does_not_pass(audience="unknown_audience")
+
+
 def test_expiration_is_required():
     authentication_does_not_pass(expiration=None)
 


### PR DESCRIPTION
With the `helusers.oidc.RequestJWTAuthentication` it's now possible to compare the JWT's `aud` claim to multiple possible values. I.e. this kind of setting is now possible:

```python
OIDC_API_TOKEN_AUTH = {
    "AUDIENCE": [ "audience_1", "audience_2" ] 
}
```

Documentation for this feature isn't included in this PR but will be added to the documentation rewrite PR #41 where the whole `RequestJWTAuthentication` documentation is pending final approval.