### PR TITLE
Compare "Bearer" case insensitively

### DIFF
--- a/helusers/oidc.py
+++ b/helusers/oidc.py
@@ -105,7 +105,7 @@ class RequestJWTAuthentication:
         try:
             auth_header = request.headers["Authorization"]
             auth_scheme, jwt_value = auth_header.split()
-            if auth_scheme != "Bearer":
+            if auth_scheme.lower() != "bearer":
                 return None
             jwt = JWT(jwt_value)
         except Exception:

--- a/helusers/tests/test_oidc_request_jwt_authentication.py
+++ b/helusers/tests/test_oidc_request_jwt_authentication.py
@@ -242,8 +242,9 @@ def test_if_authorization_header_does_not_contain_a_jwt_returns_none(rf, auth):
 
 
 @pytest.mark.django_db
-def test_bearer_authentication_scheme_is_accepted():
-    authentication_passes(auth_scheme="Bearer")
+@pytest.mark.parametrize("scheme", ["Bearer", "bearer", "BEARER", "BeArEr"])
+def test_bearer_authentication_scheme_is_accepted(scheme):
+    authentication_passes(auth_scheme=scheme)
 
 
 def test_other_than_bearer_authentication_scheme_makes_authentication_skip():


### PR DESCRIPTION
I can't find any definitive specification about whether the "Bearer" word should be compared case sensitively or insensitively. But I've seen both "Bearer" and "bearer" used in real Authorization headers, so it's probably safest to use case insensitive comparison.