### PR TITLE
Fix ugettext deprecation warnings in Django 3.0

### DIFF
--- a/helusers/_oidc_auth_impl.py
+++ b/helusers/_oidc_auth_impl.py
@@ -2,7 +2,7 @@ import logging
 import requests
 from django.utils.encoding import smart_text
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from oidc_auth.authentication import JSONWebTokenAuthentication
 from oidc_auth.util import cache
 from rest_framework.authentication import get_authorization_header

--- a/helusers/_rest_framework_jwt_impl.py
+++ b/helusers/_rest_framework_jwt_impl.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from rest_framework import exceptions
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 from rest_framework_jwt.settings import api_settings

--- a/helusers/admin_site.py
+++ b/helusers/admin_site.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 
 
@@ -35,8 +35,8 @@ class AdminSite(admin.AdminSite):
         elif hasattr(settings, 'WAGTAIL_SITE_NAME'):
             site_name = settings.WAGTAIL_SITE_NAME
         else:
-            return ugettext_lazy("Django admin")
-        return ugettext_lazy("%(site_name)s admin") % {'site_name': site_name}
+            return _("Django admin")
+        return _("%(site_name)s admin") % {'site_name': site_name}
 
     def each_context(self, request):
         ret = super(AdminSite, self).each_context(request)

--- a/helusers/apps.py
+++ b/helusers/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.admin.apps import AdminConfig
 
 

--- a/helusers/models.py
+++ b/helusers/models.py
@@ -2,7 +2,7 @@ import uuid
 import logging
 from django.db import models, transaction
 from django.contrib.auth.models import Group, AbstractUser as DjangoAbstractUser
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .utils import uuid_to_username
 

--- a/helusers/user_utils.py
+++ b/helusers/user_utils.py
@@ -1,7 +1,7 @@
 import logging
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.db import transaction, IntegrityError
 from uuid import UUID, uuid5
 


### PR DESCRIPTION
django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().

django.utils.translation.ugettext() is deprecated in favor of django.utils.translation.gettext().

https://docs.djangoproject.com/en/3.1/releases/3.0/#id3