### PR TITLE
Add HelusersConfig.default_auto_field for Django 3.2

### DIFF
--- a/helusers/apps.py
+++ b/helusers/apps.py
@@ -6,6 +6,7 @@ from django.contrib.admin.apps import AdminConfig
 class HelusersConfig(AppConfig):
     name = 'helusers'
     verbose_name = _("Helsinki Users")
+    default_auto_field = "django.db.models.AutoField"
 
 
 class HelusersAdminConfig(AdminConfig):


### PR DESCRIPTION
Projects using Django >=3.2 will/can define `DEFAULT_AUTO_FIELD` which for new projects will be `BigAutoField`. To avoid unwanted migrations in the future `default_auto_field` will be configured to `django.db.models.AutoField`.

Refs https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys