### PR TITLE
Separate list from the next paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The settings are:
 * client ID
 * client secret
 * Tunnistamo OIDC endpoint
+
 `Client` is OAuth2 / OIDC name for anything wanting to authenticate
 users. Thus your application would be a `client`
 


### PR DESCRIPTION
Markdown requires an empty line to end a list.