### PR TITLE
Specify social_auth urls only when social_auth is in use

### DIFF
--- a/helusers/urls.py
+++ b/helusers/urls.py
@@ -5,13 +5,19 @@ from django.core.exceptions import ImproperlyConfigured
 from . import views
 
 
-app_name = 'helusers'
+app_name = "helusers"
 
 urlpatterns = [
-    path('logout/', views.LogoutView.as_view(), name='auth_logout'),
-    path('logout/complete/', views.LogoutCompleteView.as_view(), name='auth_logout_complete'),
-    path('login/', views.LoginView.as_view(), name='auth_login'),
+    path("logout/", views.LogoutView.as_view(), name="auth_logout"),
+    path(
+        "logout/complete/",
+        views.LogoutCompleteView.as_view(),
+        name="auth_logout_complete",
+    ),
+    path("login/", views.LoginView.as_view(), name="auth_login"),
 ]
 
 if not settings.LOGOUT_REDIRECT_URL:
-    raise ImproperlyConfigured("You must configure LOGOUT_REDIRECT_URL to use helusers views.")
+    raise ImproperlyConfigured(
+        "You must configure LOGOUT_REDIRECT_URL to use helusers views."
+    )

--- a/helusers/urls.py
+++ b/helusers/urls.py
@@ -16,7 +16,7 @@ if (
 ):
     if not settings.LOGOUT_REDIRECT_URL:
         raise ImproperlyConfigured(
-            "You must configure LOGOUT_REDIRECT_URL to use helusers views."
+            "LOGOUT_REDIRECT_URL setting must be set to use social_auth login/logout with helusers."
         )
 
     urlpatterns.extend(

--- a/helusers/urls.py
+++ b/helusers/urls.py
@@ -9,19 +9,24 @@ app_name = "helusers"
 
 urlpatterns = []
 
-if not settings.LOGOUT_REDIRECT_URL:
-    raise ImproperlyConfigured(
-        "You must configure LOGOUT_REDIRECT_URL to use helusers views."
-    )
+if (
+    "social_django" in settings.INSTALLED_APPS
+    and "helusers.tunnistamo_oidc.TunnistamoOIDCAuth"
+    in settings.AUTHENTICATION_BACKENDS
+):
+    if not settings.LOGOUT_REDIRECT_URL:
+        raise ImproperlyConfigured(
+            "You must configure LOGOUT_REDIRECT_URL to use helusers views."
+        )
 
-urlpatterns.extend(
-    [
-        path("logout/", views.LogoutView.as_view(), name="auth_logout"),
-        path(
-            "logout/complete/",
-            views.LogoutCompleteView.as_view(),
-            name="auth_logout_complete",
-        ),
-        path("login/", views.LoginView.as_view(), name="auth_login"),
-    ]
-)
+    urlpatterns.extend(
+        [
+            path("logout/", views.LogoutView.as_view(), name="auth_logout"),
+            path(
+                "logout/complete/",
+                views.LogoutCompleteView.as_view(),
+                name="auth_logout_complete",
+            ),
+            path("login/", views.LoginView.as_view(), name="auth_login"),
+        ]
+    )

--- a/helusers/urls.py
+++ b/helusers/urls.py
@@ -7,17 +7,21 @@ from . import views
 
 app_name = "helusers"
 
-urlpatterns = [
-    path("logout/", views.LogoutView.as_view(), name="auth_logout"),
-    path(
-        "logout/complete/",
-        views.LogoutCompleteView.as_view(),
-        name="auth_logout_complete",
-    ),
-    path("login/", views.LoginView.as_view(), name="auth_login"),
-]
+urlpatterns = []
 
 if not settings.LOGOUT_REDIRECT_URL:
     raise ImproperlyConfigured(
         "You must configure LOGOUT_REDIRECT_URL to use helusers views."
     )
+
+urlpatterns.extend(
+    [
+        path("logout/", views.LogoutView.as_view(), name="auth_logout"),
+        path(
+            "logout/complete/",
+            views.LogoutCompleteView.as_view(),
+            name="auth_logout_complete",
+        ),
+        path("login/", views.LoginView.as_view(), name="auth_login"),
+    ]
+)

--- a/helusers/views.py
+++ b/helusers/views.py
@@ -9,14 +9,14 @@ from django.contrib import messages
 from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 
-LANGUAGE_FIELD_NAME = 'ui_locales'
+LANGUAGE_FIELD_NAME = "ui_locales"
 
 
 class LogoutView(DjangoLogoutView):
     def dispatch(self, request, *args, **kwargs):
         was_authenticated = request.user.is_authenticated
         session = request.session
-        end_session_url = session.get('social_auth_end_session_url')
+        end_session_url = session.get("social_auth_end_session_url")
         if end_session_url:
             self.next_page = end_session_url
         ret = super().dispatch(request, *args, **kwargs)
@@ -39,7 +39,7 @@ class LoginView(RedirectView):
         # method is connected to an existing user account.
         logout(self.request)
 
-        url = reverse('social:begin', kwargs=dict(backend='tunnistamo'))
+        url = reverse("social:begin", kwargs=dict(backend="tunnistamo"))
         redirect_to = self.request.GET.get(REDIRECT_FIELD_NAME)
         lang = self.request.GET.get(LANGUAGE_FIELD_NAME)
 
@@ -49,6 +49,6 @@ class LoginView(RedirectView):
         if lang:
             query_params[LANGUAGE_FIELD_NAME] = lang
         if query_params:
-            url += '?' + urlencode(query_params)
+            url += "?" + urlencode(query_params)
 
         return url


### PR DESCRIPTION
The `urls.py` file was completely dedicated for the use case where the project uses `social_auth` and `django-helusers` for login/logout functionality (using the `helusers.tunnistamo_oidc.TunnistamoOIDCAuth` authentication backend). After this PR the URLs present in that file are only configured in case `social_auth` and `helusers.tunnistamo_oidc.TunnistamoOIDCAuth` are actually used. This enables adding other features to the `urls.py` file as well, selectable by the user of `django-helusers` library.