### PR TITLE
Require at least Django version 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - An [OIDC back channel logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) endpoint implementation.
 
+### Changed
+
+- Set required Django version to 2.2 and later.
+
 ### Removed
 
 - The `key_provider` argument of `helusers.oidc.RequestJWTAuthentication.__init__` method was removed. It existed only for test support, but tests have been modified in a way that it's not needed any more.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='City of Helsinki',
     author_email='dev@hel.fi',
     install_requires=[
-        'Django',
+        'Django>=2.2',
         'cachetools>=3.0.0',
         'deprecation>=2',
         'requests',


### PR DESCRIPTION
Currently 2.2 is the oldest version series that is still supported by the Django project. There's no point pretending that django-helusers would support something older.