### PR TITLE
Fix default AppConfig

### DIFF
--- a/helusers/apps.py
+++ b/helusers/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
-from django.contrib.admin.apps import AdminConfig
+from django.contrib.admin import apps
 
 
 class HelusersConfig(AppConfig):
@@ -9,5 +9,5 @@ class HelusersConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
 
-class HelusersAdminConfig(AdminConfig):
+class HelusersAdminConfig(apps.AdminConfig):
     default_site = 'helusers.admin_site.AdminSite'


### PR DESCRIPTION
Importing AdminConfig directly results in ''helusers.apps' declares more than one default AppConfig' error in Django 3.2