### PR TITLE
Set up tox for multiple test environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,28 +8,43 @@ on:
 
 jobs:
   test:
-    name: Tests with pytest
-    runs-on: ubuntu-latest
+    name: Python ${{ matrix.python_version }}
+    runs-on: ubuntu-20.04  # Ubuntu 20.04 is required for Python 3.6
+    env:
+      TOX_POSARGS: -- --cov=. --cov-report=xml
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python_version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
+        cache: 'pip'
+        cache-dependency-path: 'requirements-test.txt'
+
+    - name: Upgrade packaging tools
+      run: python -m pip install --upgrade pip setuptools wheel
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install pip-tools
-        pip-compile requirements-dev.in
-        pip install -r requirements-dev.txt
-    - name: Run tests
-      run: |
-        pytest --cov=. --cov-report=xml
+      run: python -m pip install --upgrade codecov tox
+
+    # Python 3.6 doesn't have tox4, so we need to install tox-py to imitate -f
+    - name: Install tox-py for Python 3.6
+      if: ${{ matrix.python_version == '3.6' }}
+      run: python -m pip install --upgrade tox-py
+
+    - name: Run tox targets for Python > 3.6 (currently ${{ matrix.python_version }})
+      if: ${{ matrix.python_version != '3.6' }}
+      run: tox run -f py$(echo ${{ matrix.python_version }} | tr -d .) ${{ env.TOX_POSARGS }}
+
+    - name: Run tox targets for Python 3.6 (currently ${{ matrix.python_version }})
+      if: ${{ matrix.python_version == '3.6' }}
+      run: tox --py current ${{ env.TOX_POSARGS }}
+
     - name: Upload Coverage to Codecov
       if: ${{ matrix.python_version == '3.9' }}
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /dist
 /build
 /django_helusers.egg-info
-requirements-dev*.txt
 .venv/
 .vscode/
 .tox

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 requirements-dev*.txt
 .venv/
 .vscode/
+.tox
+.coverage

--- a/README.md
+++ b/README.md
@@ -434,9 +434,7 @@ pip install -e .
 Install development requirements:
 
 ```bash
-pip install pip-tools
-pip-compile requirements-dev.in
-pip install -r requirements-dev.txt
+pip install -r requirements-test.txt
 ```
 
 ## Running tests

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Django-helusers is your friendly app for bolting authentication into Django proj
 
 A baseline `User` model is provided that can be used with the various authentication use cases that are supported. The model supports mapping from AD groups to Django groups based on the authentication data.
 
-Additionally there are **optional** functionalities that can be used as needed.
+Additionally, there are **optional** functionalities that can be used as needed.
 
 Functionalities for server needing (API) access token verification:
 
@@ -443,4 +443,11 @@ pip install -r requirements-dev.txt
 
 ```bash
 pytest
+```
+
+You can run the tests against multiple environments by using [tox](https://tox.readthedocs.io/en/latest/).
+Install `tox` globally and run:
+
+```bash
+tox
 ```

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,8 +1,0 @@
-django<4
-django-allauth
-drf-oidc-auth
-pytest
-pytest-cov
-pytest-django
-pytest-mock
-responses

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-# This is for running tox
 django-allauth
 drf-oidc-auth
 pytest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,8 @@
+# This is for running tox
+django-allauth
+drf-oidc-auth
+pytest
+pytest-cov
+pytest-django
+pytest-mock
+responses

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist =
+    py36-django{22,30,31,32}
+    py37-django{22,30,31,32}
+    py38-django{22,30,31,32}
+    py39-django{22,30,31,32}
+
+[testenv]
+description = run unit tests
+commands = pytest {posargs}
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+    PYTHONWARNINGS=once
+deps =
+    django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<4.0
+    -rrequirements-test.txt


### PR DESCRIPTION
Set up [tox](https://tox.wiki/en/latest/) for the project. This enables testing for multiple environments, i.e. different combinations of Python and Django versions.

Included targets:
- Python 3.6, 3.7, 3.8, 3.9
- Django 2.2, 3.0, 3.1, 3.2