### PR TITLE
Prepare for release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.8.0 - 2023-03-16
 
-### Changed
+### Added
 
-- Drop support for Python 3.6
-- Drop support for Django 2.2
-- Add support for Python 3.10 & 3.11
-- Add support for Django >=4.0
+- Support for Python 3.10 & 3.11
+- Support for Django >=4.0
+
+### Removed
+
+- Support for Python 3.6
+- Support for Django 2.2
 
 ## 0.7.1 - 2022-04-12
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-helusers',
-    version='0.7.1',
+    version='0.8.0',
     packages=['helusers'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Bump version to 0.8.0. Reformatted the changelog to follow the existing sections.