### PR TITLE
Fix admin site logout

### DIFF
--- a/helusers/admin_site.py
+++ b/helusers/admin_site.py
@@ -6,7 +6,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.views.decorators.cache import never_cache
 
 
 if hasattr(settings, 'SITE_TYPE'):
@@ -72,7 +71,6 @@ class AdminSite(admin.AdminSite):
 
         return ret
 
-    @never_cache
     def logout(self, request, extra_context=None):
         if request.session and request.session.get('social_auth_end_session_url'):
             logout_url = reverse('helusers:auth_logout')


### PR DESCRIPTION
This PR fixes admin site logout in Django 4+

Currently, if you try to log out from the admin site, you are greeted with this error and cannot log out:
![image](https://user-images.githubusercontent.com/2333857/226613630-afa1708c-b9ca-4362-9064-8bf540169c5a.png)

This is caused by the `never_cache` method decorator not being wrapped by the `method_decorator` decorator. [Method decorators have to be inside `@method_decorator` decorator.](https://docs.djangoproject.com/en/4.1/topics/class-based-views/intro/#decorating-the-class) Judging by the documentation history, not a very new thing, but seems to manifest fully in Django 4.

Tested locally with my current project, which I am upgrading from Django 3.2 to 4.1.