### PR TITLE
Convert JWT amr to list if string

### DIFF
--- a/helusers/_oidc_auth_impl.py
+++ b/helusers/_oidc_auth_impl.py
@@ -47,6 +47,14 @@ class ApiTokenAuthentication(JSONWebTokenAuthentication):
             logger.debug("Invalid token signature")
             raise
 
+        # Some OPs may provide the "amr" incorrectly as a string, while the
+        # specification dictates it must be an array of strings. Fix that here.
+        if isinstance(payload.get("amr"), str):
+            payload["amr"] = [payload["amr"]]
+            logger.debug(
+                'Modified "amr" claim to be an array of strings instead of a string.'
+            )
+
         logger.debug("Token payload decoded as: {}".format(payload))
 
         self.validate_claims(payload)

--- a/helusers/tests/test_oidc_api_token_authentication.py
+++ b/helusers/tests/test_oidc_api_token_authentication.py
@@ -4,7 +4,7 @@ import pytest
 
 from helusers.oidc import ApiTokenAuthentication
 
-from .conftest import encoded_jwt_factory, ISSUER1
+from .conftest import ISSUER1, encoded_jwt_factory
 
 
 @pytest.fixture(autouse=True)
@@ -12,19 +12,36 @@ def auto_auth_server(auth_server):
     return auth_server
 
 
-@pytest.mark.django_db
-def test_valid_jwt_is_accepted(rf, unix_timestamp_now):
-    sut = ApiTokenAuthentication()
+@pytest.fixture
+def user_uuid():
+    return uuid.UUID("b7a35517-eb1f-46c9-88bf-3206fb659c3c")
 
-    user_uuid = uuid.UUID("b7a35517-eb1f-46c9-88bf-3206fb659c3c")
 
-    encoded_jwt = encoded_jwt_factory(
+@pytest.fixture
+def jwt_data(user_uuid, unix_timestamp_now):
+    return dict(
         iss=ISSUER1,
         aud="test_audience",
         iat=unix_timestamp_now - 10,
         exp=unix_timestamp_now + 1000,
         sub=str(user_uuid),
     )
+
+
+@pytest.mark.parametrize(
+    "jwt_data_extra",
+    [
+        dict(),
+        dict(amr="something"),
+        dict(amr=["something"]),
+    ],
+)
+@pytest.mark.django_db
+def test_valid_jwt_is_accepted(rf, jwt_data, user_uuid, jwt_data_extra):
+    sut = ApiTokenAuthentication()
+
+    jwt_data.update(jwt_data_extra)
+    encoded_jwt = encoded_jwt_factory(**jwt_data)
 
     request = rf.get("/path", HTTP_AUTHORIZATION=f"Bearer {encoded_jwt}")
 


### PR DESCRIPTION
As discussed here: https://github.com/City-of-Helsinki/django-helusers/issues/73

This converts `amr` to a list if it's a string.

Apparently, Tunnistamo sends `amr` as a string, not a list. This screws things up if `drf-oidc-auth`'s version is >=1.0.0. However, `drf-oidc-auth` >=1.0.0 is required for Django 4, so something needs to be done. I went with @nikomakela's suggestion.

I suppose it's not a perfect solution, but it should do the job for the time being.