### PR TITLE
Validate aud claim in ApiTokenAuthentication

### DIFF
--- a/helusers/_oidc_auth_impl.py
+++ b/helusers/_oidc_auth_impl.py
@@ -20,6 +20,21 @@ class ApiTokenAuthentication(JSONWebTokenAuthentication):
         self.settings = settings or api_token_auth_settings
         super(ApiTokenAuthentication, self).__init__(**kwargs)
 
+    @property
+    # This method is used if the drf-oidc-auth dependecy version is 1.0.0 or greater
+    def claims_options(self):
+        _claims_options = super().claims_options
+
+        audiences = self.settings.AUDIENCE
+        if isinstance(audiences, str):
+            audiences = [self.settings.AUDIENCE]
+
+        _claims_options["aud"] = {
+            "essential": True,
+            "values": audiences
+        }
+        return _claims_options
+
     @cached_property
     def auth_scheme(self):
         return self.settings.AUTH_SCHEME or 'Bearer'
@@ -98,6 +113,7 @@ class ApiTokenAuthentication(JSONWebTokenAuthentication):
             auth_scheme=self.auth_scheme,
             realm=self.www_authenticate_realm)
 
+    # This method is only used if the drf-oidc-auth dependecy version is less than 1.0.0
     def get_audiences(self, api_token):
         return {self.settings.AUDIENCE}
 

--- a/helusers/locale/fi/LC_MESSAGES/django.po
+++ b/helusers/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-09 12:32+0200\n"
+"POT-Creation-Date: 2023-06-13 04:44-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: helusers/_oidc_auth_impl.py
+#, python-brace-format
+msgid "Not authorized for API scope \"{api_scope}\""
+msgstr ""
+
+#: helusers/_oidc_auth_impl.py
+msgid "Invalid Authorization header. No credentials provided"
+msgstr ""
+
+#: helusers/_oidc_auth_impl.py
+msgid ""
+"Invalid Authorization header. Credentials string should not contain spaces."
+msgstr ""
+
+#: helusers/_rest_framework_jwt_impl.py
+msgid "User account is disabled."
+msgstr "Käyttäjätunnus on pois käytöstä."
 
 #: helusers/admin_site.py
 msgid "Django admin"
@@ -31,10 +49,6 @@ msgstr "Sivuston %(site_name)s ylläpito"
 msgid "Helsinki Users"
 msgstr "Käyttäjät"
 
-#: helusers/jwt.py
-msgid "User account is disabled."
-msgstr "Käyttäjätunnus on pois käytöstä."
-
 #: helusers/models.py
 #, fuzzy
 #| msgid "AD Group Mapping"
@@ -45,19 +59,6 @@ msgstr "AD-ryhmätaulu"
 msgid "AD group mappings"
 msgstr "AD-ryhmätaulut"
 
-#: helusers/oidc.py
-#, python-brace-format
-msgid "Not authorized for API scope \"{api_scope}\""
-msgstr ""
-
-#: helusers/oidc.py
-msgid "Invalid Authorization header. No credentials provided"
-msgstr ""
-
-#: helusers/oidc.py
-msgid "Invalid Authorization header. Credentials string should not contain spaces."
-msgstr ""
-
 #: helusers/templates/admin/base_site_default.html
 msgid "Django site admin"
 msgstr "Sivuston ylläpito"
@@ -67,7 +68,7 @@ msgid "Django administration"
 msgstr "Ylläpito"
 
 #: helusers/user_utils.py
-msgid "Invalid payload."
+msgid "Invalid payload. sub missing"
 msgstr ""
 
 #: helusers/views.py


### PR DESCRIPTION
drf-oidc-auth changed from jwkest to authlib in a PR* where the accepted
audiences are read from a new setting and not from `get_audiences`
method. By default, every audience is accepted in authlib.

Changed claims_options to use our own audience setting.

* https://github.com/ByteInternet/drf-oidc-auth/pull/42