### PR TITLE
Remove drf-oidc-auth requirement when using ApiTokenAuthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+
+## Upcoming - 2023-xx-xx
+
+### Fixed
+
+- `ApiTokenAuthentication` again validates the `aud` claim. The `aud` claim wasn't validated if the `drf-oidc-auth` version was 1.0.0 or greater.
+
+### Added
+- Documentation about social auth pipeline configuration
+
+### Removed 
+
+- Removed `drf-oidc-auth` requirement when using `ApiTokenAuthentication`. Django REST framework is still required.
+
+### Changed
+
+- `ApiTokenAuthentication` is no longer a subclass of `oidc_auth.authentication.JSONWebTokenAuthentication` but a direct subclass of `rest_framework.authentication.BaseAuthentication`
+- `ApiTokenAuthentication` uses the same `JWT` class as `RequestJWTAuthentication` for the token validation
+  - **Changed** methods:
+    - `decode_jwt` can raise `jose.JWTError` exception
+    - `get_oidc_config` no longer returns oidc configuration dictionary but an `OIDCConfig` instance
+    - `validate_claims` still exists and is called, but doesn't do anything
+  - **Removed** methods:
+    - `get_audiences`
+    - `jwks`
+    - `jwks_data`
+    - `oidc_config`
+  - **Removed** properties:
+    - `claims_options`
+    - `issuer`
+
+- `ApiTokenAuthentication` now supports multiple issuers. Previously it accepted multiple issuers in the settings but could only use the first issuer.
+- `ApiTokenAuthentication.authenticate` no longer raises AuthenticationError if authorization header contains the correct scheme but not a valid JWT-token. Now it just returns None which means the authentication didn't succeed but can be tried with the next authenticator.
+- `ApiTokenAuthentication` now rejects tokens if they are invalidated with back-channel log out
+- `amr` claim is no longer validated in `ApiTokenAuthentication`
+- Issued at (`iat`) claim is no longer limited by the OIDC_LEEWAY oidc_auth setting (default 10 minutes) when using `ApiTokenAuthentication`. i.e. tokens can be generated as long ago as needed.
+- User is no longer created if token is correct but is missing the required API scopes in `ApiTokenAuthentication`
+
 ## 0.8.1 - 2023-04-04
 
 ### Fixed

--- a/helusers/_oidc_auth_impl.py
+++ b/helusers/_oidc_auth_impl.py
@@ -1,57 +1,35 @@
 import logging
-import requests
-from authlib.jose import JoseError
-from authlib.jose.errors import ExpiredTokenError
+
+from cachetools.func import ttl_cache
 from django.utils.encoding import smart_str
-from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
-from oidc_auth.authentication import JSONWebTokenAuthentication
-from oidc_auth.util import cache
-from rest_framework.authentication import get_authorization_header
+from jose import JWTError
+from rest_framework.authentication import BaseAuthentication, get_authorization_header
 from rest_framework.exceptions import AuthenticationFailed
 
 from .authz import UserAuthorization
+from .jwt import JWT, ValidationError
 from .settings import api_token_auth_settings
 from .user_utils import get_or_create_user
 
 logger = logging.getLogger(__name__)
 
 
-class ApiTokenAuthentication(JSONWebTokenAuthentication):
+class ApiTokenAuthentication(BaseAuthentication):
+    www_authenticate_realm = "api"
+
     def __init__(self, settings=None, **kwargs):
         self.settings = settings or api_token_auth_settings
         super(ApiTokenAuthentication, self).__init__(**kwargs)
 
     @property
-    # This method is used if the drf-oidc-auth dependecy version is 1.0.0 or greater
-    def claims_options(self):
-        _claims_options = super().claims_options
-
-        audiences = self.settings.AUDIENCE
-        if isinstance(audiences, str):
-            audiences = [self.settings.AUDIENCE]
-
-        _claims_options["aud"] = {
-            "essential": True,
-            "values": audiences
-        }
-        return _claims_options
-
-    @cached_property
     def auth_scheme(self):
-        return self.settings.AUTH_SCHEME or 'Bearer'
+        return self.settings.AUTH_SCHEME or "Bearer"
 
-    @property
-    def oidc_config(self):
-        return self.get_oidc_config()
-
-    @cache(ttl=api_token_auth_settings.OIDC_CONFIG_EXPIRATION_TIME)
-    def get_oidc_config(self):
-        issuer = self.settings.ISSUER
-        if not isinstance(issuer, str):
-            issuer = issuer[0]
-        url = issuer + '/.well-known/openid-configuration'
-        return requests.get(url).json()
+    @ttl_cache(ttl=api_token_auth_settings.OIDC_CONFIG_EXPIRATION_TIME)
+    def get_oidc_config(self, issuer):
+        from helusers.oidc import OIDCConfig
+        return OIDCConfig(issuer)
 
     def authenticate(self, request):
         jwt_value = self.get_jwt_value(request)
@@ -60,21 +38,10 @@ class ApiTokenAuthentication(JSONWebTokenAuthentication):
 
         try:
             payload = self.decode_jwt(jwt_value)
-        except AuthenticationFailed as e:
-            logger.debug("Invalid token signature")
-            raise
-
-        # Some OPs may provide the "amr" incorrectly as a string, while the
-        # specification dictates it must be an array of strings. Fix that here.
-        if isinstance(payload.get("amr"), str):
-            payload["amr"] = [payload["amr"]]
-            logger.debug(
-                'Modified "amr" claim to be an array of strings instead of a string.'
-            )
+        except JWTError:
+            return None
 
         logger.debug("Token payload decoded as: {}".format(payload))
-
-        self.validate_claims(payload)
 
         user_resolver = self.settings.USER_RESOLVER  # Default: resolve_user
         try:
@@ -83,14 +50,28 @@ class ApiTokenAuthentication(JSONWebTokenAuthentication):
             raise AuthenticationFailed(str(e)) from e
         auth = UserAuthorization(user, payload, self.settings)
 
-        if self.settings.REQUIRE_API_SCOPE_FOR_AUTHENTICATION:
-            api_scope = self.settings.API_SCOPE_PREFIX
-            if not auth.has_api_scope_with_prefix(api_scope):
-                raise AuthenticationFailed(
-                    _("Not authorized for API scope \"{api_scope}\"")
-                    .format(api_scope=api_scope))
+        return user, auth
 
-        return (user, auth)
+    def decode_jwt(self, jwt_value):
+        jwt = JWT(jwt_value, settings=self.settings)
+
+        try:
+            jwt.validate_issuer()
+        except ValidationError as e:
+            raise AuthenticationFailed(str(e)) from e
+
+        keys = self.get_oidc_config(jwt.issuer).keys()
+        try:
+            jwt.validate(keys, self.settings.AUDIENCE)
+            jwt.validate_api_scope()
+            jwt.validate_session()
+            self.validate_claims(jwt.claims)
+        except ValidationError as e:
+            raise AuthenticationFailed(str(e)) from e
+        except Exception:
+            raise AuthenticationFailed("JWT verification failed.")
+
+        return jwt.claims
 
     def get_jwt_value(self, request):
         auth = get_authorization_header(request).split()
@@ -111,23 +92,12 @@ class ApiTokenAuthentication(JSONWebTokenAuthentication):
         return auth[1]
 
     def validate_claims(self, id_token):
-        try:
-            id_token.validate()
-        except ExpiredTokenError:
-            msg = _('Invalid Authorization header. JWT has expired.')
-            raise AuthenticationFailed(msg)
-        except JoseError as e:
-            msg = _(str(type(e)) + str(e))
-            raise AuthenticationFailed(msg)
+        """Not in use. Only for backwards compatibility"""
 
     def authenticate_header(self, request):
         return '{auth_scheme} realm="{realm}"'.format(
             auth_scheme=self.auth_scheme,
             realm=self.www_authenticate_realm)
-
-    # This method is only used if the drf-oidc-auth dependecy version is less than 1.0.0
-    def get_audiences(self, api_token):
-        return {self.settings.AUDIENCE}
 
 
 def resolve_user(request, payload):

--- a/helusers/locale/fi/LC_MESSAGES/django.po
+++ b/helusers/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-13 09:34-0500\n"
+"POT-Creation-Date: 2023-06-20 23:51-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,21 +19,12 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: helusers/_oidc_auth_impl.py
-#, python-brace-format
-msgid "Not authorized for API scope \"{api_scope}\""
-msgstr ""
-
-#: helusers/_oidc_auth_impl.py
 msgid "Invalid Authorization header. No credentials provided"
 msgstr ""
 
 #: helusers/_oidc_auth_impl.py
 msgid ""
 "Invalid Authorization header. Credentials string should not contain spaces."
-msgstr ""
-
-#: helusers/_oidc_auth_impl.py
-msgid "Invalid Authorization header. JWT has expired."
 msgstr ""
 
 #: helusers/_rest_framework_jwt_impl.py

--- a/helusers/tests/test_jwt_token_authentication.py
+++ b/helusers/tests/test_jwt_token_authentication.py
@@ -105,6 +105,20 @@ def test_issuer_is_required(sut):
 
 
 @pytest.mark.django_db
+def test_issuer_setting_can_be_a_string(sut, settings):
+    update_oidc_settings(settings, {"ISSUER": ISSUER1})
+
+    authentication_passes(sut=sut)
+
+
+@pytest.mark.django_db
+def test_substring_doesnt_match_when_issuer_setting_is_a_string(sut, settings):
+    update_oidc_settings(settings, {"ISSUER": ISSUER1 + "/something"})
+
+    authentication_does_not_pass(sut=sut, issuer=ISSUER1)
+
+
+@pytest.mark.django_db
 def test_any_issuer_from_settings_is_accepted(sut, all_auth_servers):
     if isinstance(sut, ApiTokenAuthentication):
         pytest.skip("ApiTokenAuthentication doesn't support multiple issuers yet")

--- a/helusers/tests/test_jwt_token_authentication.py
+++ b/helusers/tests/test_jwt_token_authentication.py
@@ -120,9 +120,6 @@ def test_substring_doesnt_match_when_issuer_setting_is_a_string(sut, settings):
 
 @pytest.mark.django_db
 def test_any_issuer_from_settings_is_accepted(sut, all_auth_servers):
-    if isinstance(sut, ApiTokenAuthentication):
-        pytest.skip("ApiTokenAuthentication doesn't support multiple issuers yet")
-
     signing_key = all_auth_servers.key
     authentication_passes(sut=sut, issuer=all_auth_servers.issuer, signing_key=signing_key)
 
@@ -247,15 +244,9 @@ def test_if_authorization_header_does_not_contain_a_correct_prefix_returns_none(
     assert sut.authenticate(request) is None
 
 
-def test_if_authorization_header_does_not_contain_a_valid_jwt_returns_none(rf):
+def test_if_authorization_header_does_not_contain_a_valid_jwt_returns_none(rf, sut):
     request = rf.get("/path", HTTP_AUTHORIZATION="Bearer not_a_jwt")
-    assert RequestJWTAuthentication().authenticate(request) is None
-
-
-def test_failure_if_authorization_header_does_not_contain_a_valid_jwt(rf):
-    request = rf.get("/path", HTTP_AUTHORIZATION="Bearer not_a_jwt")
-    with pytest.raises(AuthenticationFailed):
-        ApiTokenAuthentication().authenticate(request)
+    assert sut.authenticate(request) is None
 
 
 @pytest.mark.django_db
@@ -270,9 +261,6 @@ def test_other_than_bearer_authentication_scheme_makes_authentication_skip(sut):
 
 @pytest.mark.django_db
 def test_token_belonging_to_a_logged_out_session_is_not_accepted(sut):
-    if isinstance(sut, ApiTokenAuthentication):
-        pytest.skip("ApiTokenAuthentication doesn't check for terminated sessions")
-
     iss = ISSUER1
     sub = str(USER_UUID)
     sid = "logged_out_session"

--- a/helusers/tests/test_oidc_api_token_authentication.py
+++ b/helusers/tests/test_oidc_api_token_authentication.py
@@ -1,0 +1,84 @@
+import pytest
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+from helusers._oidc_auth_impl import ApiTokenAuthentication
+from helusers.tests.test_jwt_token_authentication import (
+    USER_UUID,
+    authentication_passes,
+    do_authentication,
+    auto_auth_server,
+)
+
+
+class ReturnValueChangeApiTokenAuthentication(ApiTokenAuthentication):
+    def authenticate(self, request, **kwargs):
+        user_auth_tuple = super().authenticate(request)
+        if not user_auth_tuple:
+            return None
+        user, auth = user_auth_tuple
+        return user
+
+
+@pytest.mark.django_db
+def test_overriden_authenticate_method_works():
+    """Tests that subclasses that override authenticate method still work
+
+    Some projects use ApiTokenAuthentication with GraphlQL where the authenticator
+    should only return user and not a "user, auth"-tuple."""
+    result = do_authentication(sut=ReturnValueChangeApiTokenAuthentication())
+    assert isinstance(result, get_user_model())
+    assert result.uuid == USER_UUID
+
+
+class AmrFixApiTokenAuthentication(ApiTokenAuthentication):
+    def __convert_amr_to_list(self, id_token):
+        if id_token["amr"] and not isinstance(id_token["amr"], list):
+            id_token["amr"] = [id_token["amr"]]
+
+    def validate_claims(self, id_token):
+        self.__convert_amr_to_list(id_token)
+        super().validate_claims(id_token)
+
+
+@pytest.mark.django_db
+def test_overridden_validate_claims_method_works():
+    """Tests that subclasses that override validate_claims method still work
+
+    The ApiTokenAuthentication.validate_claims is no longer used but previously some
+    projects overrode it to fix incorrect amr-claim Tunnistamo sets. The amr fix is
+    no longer necessary because amr claim is no longer validated at all."""
+    authentication_passes(sut=AmrFixApiTokenAuthentication(), amr="test_value")
+
+
+# From https://github.com/City-of-Helsinki/kerrokantasi/blob/master/kerrokantasi/oidc.py
+class KerroKantasiApiTokenAuthentication(ApiTokenAuthentication):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def authenticate(self, request):
+        jwt_value = self.get_jwt_value(request)
+        if jwt_value is None:
+            return None
+
+        payload = self.decode_jwt(jwt_value)
+        user, auth = super().authenticate(request)
+
+        # amr (Authentication Methods References) should contain the used auth
+        # provider name e.g. suomifi
+        if payload.get('amr') in settings.STRONG_AUTH_PROVIDERS:
+            user.has_strong_auth = True
+        else:
+            user.has_strong_auth = False
+
+        user.save()
+        return (user, auth)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("amr", [None, "suomifi"])
+def test_kerrokantasi_apitokenauthentication_works(settings, amr):
+    settings.STRONG_AUTH_PROVIDERS = ["suomifi"]
+    auth = do_authentication(sut=KerroKantasiApiTokenAuthentication(), amr=amr)
+
+    assert auth.user.has_strong_auth == bool(amr)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 django-allauth
-drf-oidc-auth
+djangorestframework
 pytest
 pytest-cov
 pytest-django


### PR DESCRIPTION
drf-oidc-auth has some bugs and problems with token lifetime and
claims validation. It's also better to have only one way of validating
tokens between RequestJWTAuthentication and ApiTokenAuthentication.

Base class in ApiTokenAuthentication is changed from
oidc_auth.authentication.JSONWebTokenAuthentication to
rest_framework.authentication.BaseAuthentication. Some methods from
JSONWebTokenAuthentication are kept for backwards compatibility but
the token validation is now handled by the JWT class.

See the CHANGLELOG for more detailed notes.