### PR TITLE
Change api scope checks to support claims deeper in the token structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - `ApiTokenAuthentication` again validates the `aud` claim. The `aud` claim wasn't validated if the `drf-oidc-auth` version was 1.0.0 or greater.
 
 ### Added
+
+- Ability to use "dot notation" in `API_AUTHORIZATION_FIELD` setting for searching api scopes from deeper in the claims 
 - Documentation about social auth pipeline configuration
 
 ### Removed 
@@ -16,6 +18,7 @@
 
 ### Changed
 
+- `API_AUTHORIZATION_FIELD` and `API_SCOPE_PREFIX` settings now support a list of strings
 - `ApiTokenAuthentication` is no longer a subclass of `oidc_auth.authentication.JSONWebTokenAuthentication` but a direct subclass of `rest_framework.authentication.BaseAuthentication`
 - `ApiTokenAuthentication` uses the same `JWT` class as `RequestJWTAuthentication` for the token validation
   - **Changed** methods:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ authenticated by checking the signature of the included JWT token. It still
 creates a persistent Django user, which is updated with the information
 from the token with every request.
 
-- Include `drf-oidc-auth` in your project's dependencies.
 - Configure REST framework to use the `ApiTokenAuthentication` class in `settings.py`:
 
 ```python
@@ -103,27 +102,7 @@ REST_FRAMEWORK = {
 }
 ```
 
-- Set your deployment-specific variables in `local_settings.py`, e.g.:
-
-```python
-OIDC_API_TOKEN_AUTH = {
-    # Audience that must be present in the token for the request to be
-    # accepted. Value must be agreed between your SSO service and your
-    # application instance. Essentially this allows your application to
-    # know that the token in meant to be used with it.
-    'AUDIENCE': 'https://api.hel.fi/auth/projects',
-    # Who we trust to sign the tokens. The library will request the
-    # public signature keys from standard locations below this URL
-    'ISSUER': 'https://api.hel.fi/sso/openid'
-    # The following can be used if you need certain OAuth2 scopes
-    # for any functionality of the API. The request will be denied
-    # if scopes starting with API_SCOPE_PREFIX are not present
-    # in the token claims. Usually this is not needed, as checking
-    # the audience is enough.
-    'REQUIRE_API_SCOPE_FOR_AUTHENTICATION': True,
-    'API_SCOPE_PREFIX': 'projects',
-}
-```
+- Set your deployment-specific variables in your project settings. See [Token authentication settings](#token-authentication-settings)
 
 ### API authentication using JWT in any setup
 
@@ -137,7 +116,10 @@ It has a method called `authenticate` that takes a [Django HttpRequest](https://
 User of this class can use it in any way they need to perform authentication and/or authorization.
 Check the class documentation for more details.
 
-Some settings are needed (and some are optional) that affect how the `RequestJWTAuthentication` class works.
+
+### Token authentication settings
+
+Some settings are needed (and some are optional) that affect how the `ApiTokenAuthentication` and `RequestJWTAuthentication` classes work.
 
 ```python
 OIDC_API_TOKEN_AUTH = {
@@ -145,30 +127,33 @@ OIDC_API_TOKEN_AUTH = {
     # accepted. Value must be agreed between your SSO service and your
     # application instance. Essentially this allows your application to
     # know that the token is meant to be used with it.
-    # RequestJWTAuthentication supports multiple acceptable audiences,
+    # Multiple acceptable audiences are supported,
     # so this setting can also be a list of strings.
     # This setting is required.
     'AUDIENCE': 'https://api.hel.fi/auth/projects',
 
     # Who we trust to sign the tokens. The library will request the
     # public signature keys from standard locations below this URL.
-    # RequestJWTAuthentication supports multiple issuers, so this
+    # Multiple issuers are supported, so this
     # setting can also be a list of strings.
     # Default is https://tunnistamo.hel.fi.
-    'ISSUER': 'https://api.hel.fi/sso/openid'
+    'ISSUER': 'https://api.hel.fi/sso/openid',
 
     # The following can be used if you need certain scopes for any
     # functionality of the API. Usually this is not needed, as checking
     # the audience is enough. Default is False.
     'REQUIRE_API_SCOPE_FOR_AUTHENTICATION': True,
     # The name of the claim that is used to read in the scopes from the JWT.
+    # Supports multiple fields as a list. If the field is deeper in the claims
+    # use dot notation. e.g. "authorization.permissions.scopes"
     # Default is https://api.hel.fi/auth.
     'API_AUTHORIZATION_FIELD': 'scope_field',
     # The request will be denied if scopes don't contain anything starting
-    # with the value provided here.
+    # with the value provided here. Supports multiple scope prefixes as a list.
+    # Only one scope needs to match if multiple prefixes are provided.
     'API_SCOPE_PREFIX': 'projects',
 
-    # In order to do the authentication RequestJWTAuthentication needs
+    # In order to do the authentication the token authentication classes need
     # some facts from the authorization server, mainly its public keys for
     # verifying the JWT's signature. This setting controls the time how long
     # authorization server configuration and public keys are "remembered".
@@ -194,7 +179,7 @@ OIDC_API_TOKEN_AUTH = {
     # the public signature keys from standard locations below this URL.
     # Multiple issuers are supported, so this setting can also be a list
     # of strings. Default is https://tunnistamo.hel.fi.
-    'ISSUER': 'https://api.hel.fi/sso/openid'
+    'ISSUER': 'https://api.hel.fi/sso/openid',
 
     # Audience that must be present in the logout token for it to
     # be accepted. Value must be agreed between your SSO service

--- a/helusers/authz.py
+++ b/helusers/authz.py
@@ -1,6 +1,7 @@
 from django.utils.functional import cached_property
 
 from .settings import api_token_auth_settings
+from .utils import get_scopes_from_claims
 
 
 class UserAuthorization(object):
@@ -42,12 +43,4 @@ class UserAuthorization(object):
 
     @cached_property
     def _authorized_api_scopes(self):
-        api_scopes = self.data.get(self.settings.API_AUTHORIZATION_FIELD)
-        return (set(api_scopes)
-                if is_list_of_non_empty_strings(api_scopes) else None)
-
-
-def is_list_of_non_empty_strings(value):
-    if not isinstance(value, list):
-        return False
-    return all(isinstance(x, str) and x for x in value)
+        return get_scopes_from_claims(self.settings.API_AUTHORIZATION_FIELD, self.data)

--- a/helusers/settings.py
+++ b/helusers/settings.py
@@ -3,43 +3,20 @@ from django.core.signals import setting_changed
 from django.dispatch import receiver
 
 _defaults = dict(
-    # Accepted audience, the API Token must have this in its aud field
     AUDIENCE=None,
-
-    # API scope prefix for permission checks
     API_SCOPE_PREFIX=None,
-
-    # Is API scope required for successful authentication.
-    #
-    # If this setting is set, then authentication will fail, if the API
-    # scopes field doesn't contain the API_SCOPE_PREFIX or any value that
-    # starts with API_SCOPE_PREFIX and a dot.
-    #
-    # E.g. if API_SCOPE_PREFIX='xyz' and this is set to true, then the
-    # authentication will fail if the API scopes doesn't contain either
-    # 'xyz' or an item that starts with 'xyz.' (like 'xyz.readonly' or
-    # 'xyz.view').
     REQUIRE_API_SCOPE_FOR_AUTHENTICATION=False,
-
-    # Field name containing the API scopes authorized by the user
     API_AUTHORIZATION_FIELD='https://api.hel.fi/auth',
-
-    # URL of the OpenID Provider
     ISSUER='https://tunnistamo.hel.fi',
-
-    # Auth scheme used in the Authorization header
     AUTH_SCHEME='Bearer',
-
-    # Function for resolving users
     USER_RESOLVER='helusers.oidc.resolve_user',
-
-    # OIDC config expiration time
     OIDC_CONFIG_EXPIRATION_TIME=24 * 60 * 60
 )
 
 _import_strings = [
     'USER_RESOLVER',
 ]
+
 
 def _compile_settings():
     class Settings:
@@ -67,6 +44,7 @@ def _compile_settings():
             self._settings.update(user_settings)
 
     return Settings()
+
 
 api_token_auth_settings = _compile_settings()
 

--- a/helusers/tests/test_authz.py
+++ b/helusers/tests/test_authz.py
@@ -1,0 +1,58 @@
+import pytest
+
+from helusers.authz import UserAuthorization
+from helusers.tests.test_jwt_token_authentication import update_oidc_settings
+
+
+@pytest.fixture(params=[
+    {
+        "authorization_field": "https://example.com",
+        "prefix": "api_scope",
+    },
+], ids=["string settings"])
+def tunnistamo_api_scope_settings(request, settings):
+    update_oidc_settings(
+        settings,
+        {
+            "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": True,
+            "API_AUTHORIZATION_FIELD": request.param["authorization_field"],
+            "API_SCOPE_PREFIX": request.param["prefix"],
+        },
+    )
+
+
+def tunnistamo_scopes_payload(scopes):
+    return {
+        "https://example.com": scopes
+    }
+
+
+@pytest.mark.parametrize("api_token_payload,expected", [
+    [tunnistamo_scopes_payload([]), False],
+    [tunnistamo_scopes_payload(["api_scope"]), False],
+    [tunnistamo_scopes_payload(["api_scope.read"]), False],
+    [tunnistamo_scopes_payload(["api_scope", "another_api_scope"]), True],
+    [tunnistamo_scopes_payload(["api_scope", "another_api_scope", "third"]), True],
+    [tunnistamo_scopes_payload(["another_api_scope"]), False],
+], ids=str)
+def test_has_api_scopes_tunnistamo(
+    tunnistamo_api_scope_settings, api_token_payload, expected
+):
+    auth = UserAuthorization(user=None, api_token_payload=api_token_payload)
+
+    assert auth.has_api_scopes("api_scope", "another_api_scope") is expected
+
+
+@pytest.mark.parametrize("api_token_payload,expected", [
+    [tunnistamo_scopes_payload([]), False],
+    [tunnistamo_scopes_payload(["api_scope"]), True],
+    [tunnistamo_scopes_payload(["api_scope.read"]), True],
+    [tunnistamo_scopes_payload(["api_scope", "another_api_scope"]), True],
+    [tunnistamo_scopes_payload(["another_api_scope"]), False],
+], ids=str)
+def test_has_api_scope_with_prefix_tunnistamo(
+    tunnistamo_api_scope_settings, api_token_payload, expected
+):
+    auth = UserAuthorization(user=None, api_token_payload=api_token_payload)
+
+    assert auth.has_api_scope_with_prefix("api_scope") is expected

--- a/helusers/tests/test_authz.py
+++ b/helusers/tests/test_authz.py
@@ -9,7 +9,18 @@ from helusers.tests.test_jwt_token_authentication import update_oidc_settings
         "authorization_field": "https://example.com",
         "prefix": "api_scope",
     },
-], ids=["string settings"])
+    {
+        "authorization_field": ["https://example.com"],
+        "prefix": ["api_scope"],
+    },
+    {
+        "authorization_field": [
+            "https://example.com",
+            "authorization.permissions.scopes",
+        ],
+        "prefix": ["api_scope", "access"],
+    },
+], ids=["string settings","array_settings_one","array_settings_multiple"])
 def tunnistamo_api_scope_settings(request, settings):
     update_oidc_settings(
         settings,
@@ -56,3 +67,71 @@ def test_has_api_scope_with_prefix_tunnistamo(
     auth = UserAuthorization(user=None, api_token_payload=api_token_payload)
 
     assert auth.has_api_scope_with_prefix("api_scope") is expected
+
+
+@pytest.fixture(params=[
+    {
+        "authorization_field": "authorization.permissions.scopes",
+        "prefix": "access",
+    },
+    {
+        "authorization_field": ["authorization.permissions.scopes"],
+        "prefix": ["access"],
+    },
+    {
+        "authorization_field": [
+            "https://example.com",
+            "authorization.permissions.scopes",
+        ],
+        "prefix": ["api_scope", "access"],
+    },
+], ids=["string settings","array_settings_one","array_settings_multiple"])
+def keycloak_api_scope_settings(request, settings):
+    update_oidc_settings(
+        settings,
+        {
+            "REQUIRE_API_SCOPE_FOR_AUTHENTICATION": True,
+            "API_AUTHORIZATION_FIELD": request.param["authorization_field"],
+            "API_SCOPE_PREFIX": request.param["prefix"],
+        },
+    )
+
+
+def keycloak_scopes_payload(scopes):
+    return {
+        "authorization": {
+            "permissions": [
+                {"scopes": [scope]} for scope in scopes
+            ]
+        }
+    }
+
+
+@pytest.mark.parametrize("api_token_payload,expected", [
+    [keycloak_scopes_payload([]), False],
+    [keycloak_scopes_payload(["access"]), False],
+    [keycloak_scopes_payload(["access.read"]), False],
+    [keycloak_scopes_payload(["access", "second"]), True],
+    [keycloak_scopes_payload(["access", "second", "third"]), True],
+    [keycloak_scopes_payload(["second"]), False],
+], ids=str)
+def test_has_api_scopes_keycloak(
+    keycloak_api_scope_settings, api_token_payload, expected
+):
+    auth = UserAuthorization(user=None, api_token_payload=api_token_payload)
+
+    assert auth.has_api_scopes("access", "second") is expected
+
+
+@pytest.mark.parametrize("api_token_payload,expected", [
+    [keycloak_scopes_payload([]), False],
+    [keycloak_scopes_payload(["access"]), True],
+    [keycloak_scopes_payload(["access", "second"]), True],
+    [keycloak_scopes_payload(["second"]), False],
+], ids=str)
+def test_has_api_scope_with_prefix_keycloak(
+    keycloak_api_scope_settings, api_token_payload, expected
+):
+    auth = UserAuthorization(user=None, api_token_payload=api_token_payload)
+
+    assert auth.has_api_scope_with_prefix("access") is expected

--- a/helusers/utils.py
+++ b/helusers/utils.py
@@ -28,3 +28,66 @@ def username_to_uuid(username):
         raise ValueError('Not an UUID based username: %r' % (username,))
     decoded = base64.b32decode(username[2:].upper() + '======')
     return UUID(bytes=decoded)
+
+
+def get_nested_from_dict(data, full_key):
+    """Get value from a nested dictionary with dot notation
+
+    e.g.
+    >>> get_nested_from_dict({"level1": {"level2": "value"}}, "level1")
+    {'level2': 'value'}
+    >>> get_nested_from_dict({"level1": {"level2": "value"}}, "level1.level2")
+    'value'
+    >>> get_nested_from_dict({"level1": [{"level2": "value1"}, {"level2": "value2"}]}, "level1.level2")
+    ['value1', 'value2']
+    """
+    if not isinstance(data, dict) or not isinstance(full_key, str):
+        return None
+
+    key_parts = full_key.split(".")
+    first_part = key_parts.pop(0)
+
+    value = data.get(first_part, None)
+
+    if len(key_parts) == 0:
+        return value
+
+    new_key = ".".join(key_parts)
+    if isinstance(value, list):
+        return [get_nested_from_dict(val, new_key) for val in value]
+
+    return get_nested_from_dict(value, new_key)
+
+
+def flatten_list(x):
+    if isinstance(x, list):
+        return [a for i in x for a in flatten_list(i)]
+    else:
+        return [x]
+
+
+def is_list_of_non_empty_strings(value):
+    return isinstance(value, list) and all(
+        isinstance(x, str) and x for x in value
+    )
+
+
+def get_scopes_from_claims(authorization_fields, claims):
+    if not authorization_fields or not claims:
+        return None
+
+    if isinstance(authorization_fields, str):
+        authorization_fields = [authorization_fields]
+
+    collected_api_scopes = []
+    for authorization_field in authorization_fields:
+        api_scopes = claims.get(authorization_field)
+        if api_scopes is None and "." in authorization_field:
+            api_scopes = flatten_list(get_nested_from_dict(claims, authorization_field))
+            api_scopes = list(filter(None, api_scopes))
+        collected_api_scopes.extend(api_scopes)
+
+    if not is_list_of_non_empty_strings(collected_api_scopes):
+        return None
+
+    return set(collected_api_scopes)


### PR DESCRIPTION
In Tunnistamo the authorized scopes are in a claim like this:

```json
    "https://example.com/": [
      "scope",
      "scope2"
    ]
```

but in Keycloak the claims are for example:

```json
    "authorization": {
      "permissions": [
        {
          "scopes": [
            "access"
          ]
        },
        {
          "scopes": [
            "second"
          ]
        }
      ]
    },
```

So the authorization field should have a way to tell where the scopes
are if they are deeper in the claims. The _authorized_api_scopes method
is therefore changed to support authorization field with field names
separated with dots.

In the previous example the scopes could be found with the following
authorization field: "authorization.permissions.scopes".

Additionally, the API_AUTHORIZATION_FIELD and API_SCOPE_PREFIX setting
usages are changed to support multiple values so that a project can
accept tokens from two different kind of issuers at the same time.