### PR TITLE
HP-2280 | Django 5.0 admin logout support

### DIFF
--- a/helusers/admin_site.py
+++ b/helusers/admin_site.py
@@ -1,12 +1,10 @@
 import django
 from django.apps import apps
-from django.contrib import admin
 from django.conf import settings
+from django.contrib import admin
 from django.core.exceptions import ImproperlyConfigured
-from django.http import HttpResponseRedirect
-from django.urls import reverse
+from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
-
 
 if hasattr(settings, 'SITE_TYPE'):
     if settings.SITE_TYPE not in ('dev', 'test', 'production'):
@@ -73,8 +71,10 @@ class AdminSite(admin.AdminSite):
 
     def logout(self, request, extra_context=None):
         if request.session and request.session.get('social_auth_end_session_url'):
+            # This will allow e.g. to use a subclassed logout view
             logout_url = reverse('helusers:auth_logout')
-            return HttpResponseRedirect(logout_url)
+            view, args, kwargs = resolve(logout_url)
+            return view(request, *args, **kwargs)
         return super().logout(request, extra_context)
 
 

--- a/helusers/templates/admin/hel_login.html
+++ b/helusers/templates/admin/hel_login.html
@@ -1,5 +1,5 @@
 {% extends "admin/login.html" %}
-{% load static %}
+{% load i18n static %}
 
 {% block extrastyle %}
 {{ block.super }}
@@ -33,9 +33,12 @@
 {{ block.super }}
 
 {% if request.user and request.user.is_authenticated and helsinki_logout_url %}
-<a href="{{ helsinki_logout_url }}">
-    <button style="margin-left: 9em; width: auto;" class="button grp-button grp-default" type="button">Kirjaudu ulos</button>
-</a>
+<form id="logout-form" method="post" action="{{ helsinki_logout_url }}">
+    {% csrf_token %}
+    <div class="submit-row">
+        <input type="submit" value="{% translate "Log out" %}">
+    </div>
+</form>
 {% endif %}
 
 {% if grappelli_installed %}


### PR DESCRIPTION
This PR will add support for logout in Django admin (for Django 5.0). The ability to log out via GET requests in the `django.contrib.auth.views.LogoutView` and `django.contrib.auth.views.logout_then_login()` was removed in Django 5.0.