### PR TITLE
feat: define new setting ALLOWED_ALGORITHMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0 - 2024-05-20
+
+### Changed
+
+- Add new setting `ALLOWED_ALGORITHMS` with a default value of `["RS256"]`
 
 ## 0.11.0 - 2024-03-15
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ OIDC_API_TOKEN_AUTH = {
     # authorization server configuration and public keys are "remembered".
     # The value is in seconds. Default is 24 hours.
     "OIDC_CONFIG_EXPIRATION_TIME": 600,
+    
+    # Allow only algorithms that we actually use. In case of tunnistamo and
+    # tunnistus only RS256 is used with API access tokens. 
+    "ALLOWED_ALGORITHMS": ["RS256"],
 }
 ```
 

--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -50,7 +50,12 @@ class JWT:
         for required_claim in required_claims:
             options[f"require_{required_claim}"] = True
 
-        jwt.decode(self._encoded_jwt, keys, options=options)
+        jwt.decode(
+            self._encoded_jwt,
+            keys,
+            algorithms=self.settings.ALLOWED_ALGORITHMS,
+            options=options,
+        )
 
         claims = self.claims
         if require_aud and "aud" not in claims:

--- a/helusers/settings.py
+++ b/helusers/settings.py
@@ -11,6 +11,7 @@ _defaults = dict(
     AUTH_SCHEME="Bearer",
     USER_RESOLVER="helusers.oidc.resolve_user",
     OIDC_CONFIG_EXPIRATION_TIME=24 * 60 * 60,
+    ALLOWED_ALGORITHMS=["RS256"],
 )
 
 _import_strings = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-helusers",
-    version="0.11.0",
+    version="0.12.0",
     packages=["helusers"],
     include_package_data=True,
     license="BSD License",


### PR DESCRIPTION
It defaults to ["RS256"] and the goal is to mitigate CVE-2024-33663 even though vulnerability does not seem to exist in the context of tunnistamo or tunnistus (ECDSA is not used by either issuer).