### PR TITLE
chore: update requirements with missing libs

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,5 @@ pytest-django
 pytest-mock
 responses
 social-auth-app-django
+python-jose
+cachetools


### PR DESCRIPTION
The `pytest`s could not be ran before installing 2 missing dependencies: `python-jose` and `cachetools`.