### PR TITLE
Update LogoutCompleteView deprecated method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 .vscode/
 .tox
 .coverage
+.idea
+.python-version

--- a/helusers/views.py
+++ b/helusers/views.py
@@ -37,7 +37,7 @@ class LogoutView(DjangoLogoutView):
 
 class LogoutCompleteView(DjangoLogoutView):
     def dispatch(self, request, *args, **kwargs):
-        return HttpResponseRedirect(self.get_next_page())
+        return HttpResponseRedirect(self.get_success_url())
 
 
 class LoginView(RedirectView):


### PR DESCRIPTION
`LogoutView.get_next_page` has been deprecated in Django 4.1.
Use `LogoutView.get_success_url` instead.

Fixes [RATY-162](https://helsinkisolutionoffice.atlassian.net/browse/RATY-162)