### PR TITLE
feat: add `last_api_use` field to abstract user 

### DIFF
--- a/helusers/models.py
+++ b/helusers/models.py
@@ -48,6 +48,9 @@ class AbstractUser(DjangoAbstractUser):
     uuid = models.UUIDField(unique=True)
     department_name = models.CharField(max_length=50, null=True, blank=True)
     ad_groups = models.ManyToManyField(ADGroup, blank=True)
+    last_api_use = models.DateField(
+        null=True, blank=True, verbose_name=_("Latest API token usage date")
+    )
 
     def save(self, *args, **kwargs):
         self.clean()

--- a/helusers/tests/test_oidc_api_token_authentication.py
+++ b/helusers/tests/test_oidc_api_token_authentication.py
@@ -1,6 +1,7 @@
 import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 
 from helusers._oidc_auth_impl import ApiTokenAuthentication
 from helusers.tests.test_jwt_token_authentication import (  # noqa: F401
@@ -82,3 +83,11 @@ def test_kerrokantasi_apitokenauthentication_works(settings, amr):
     auth = do_authentication(sut=KerroKantasiApiTokenAuthentication(), amr=amr)
 
     assert auth.user.has_strong_auth == bool(amr)
+
+
+@pytest.mark.django_db
+def test_last_api_use_updated_on_authentication():
+    """Tests that the last_api_use field is updated on authentication."""
+    auth = do_authentication(sut=ApiTokenAuthentication())
+    user = auth.user
+    assert user.last_api_use == timezone.now().date()


### PR DESCRIPTION
Adds field to user model which indicates last usage time for the api token. Updates the time in ApiTokenAuthentication's authenticate method.

Refs: RATYK-40