### PR TITLE
Replace python-jose with PyJWT and cryptography

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 default_stages: [pre-commit, manual]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -14,18 +14,18 @@ repos:
   # Run django-upgrade before ruff, as it might alter
   # the code in a way that requires reformatting.
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.29.1"
+    rev: "1.31.1"
     hooks:
       - id: django-upgrade
         args: [--target-version, "4.2"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.15.22
     hooks:
       - id: ruff-check
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.13.0
+    rev: v9.26.0
     hooks:
       - id: commitlint
         stages: [commit-msg, manual]

--- a/helusers/_oidc_auth_impl.py
+++ b/helusers/_oidc_auth_impl.py
@@ -4,7 +4,7 @@ from cachetools.func import ttl_cache
 from django.utils import timezone
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext as _
-from jose import JWTError
+from jwt.exceptions import PyJWTError
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -40,7 +40,7 @@ class ApiTokenAuthentication(BaseAuthentication):
 
         try:
             payload = self.decode_jwt(jwt_value)
-        except JWTError:
+        except PyJWTError:
             return None
 
         logger.debug(f"Token payload decoded as: {payload}")

--- a/helusers/jwt.py
+++ b/helusers/jwt.py
@@ -9,13 +9,84 @@ try:
 except ImportError:
     pass
 
+import base64
+import json as _json
+import logging
+
+import jwt as pyjwt
 from django.utils.functional import cached_property
-from jose import jwt
+from jwt import PyJWK
 
 from .models import OIDCBackChannelLogoutEvent
 from .settings import api_token_auth_settings
 
+logger = logging.getLogger(__name__)
+
 _NOT_PROVIDED = object()
+
+
+def _get_unverified_payload(encoded_jwt):
+    """Base64-decode the JWT payload without touching the signature.
+
+    Intentionally skips signature verification — callers must call
+    JWT.validate() before trusting any claim values.
+    """
+    try:
+        if isinstance(encoded_jwt, bytes):
+            encoded_jwt = encoded_jwt.decode("utf-8")
+        parts = encoded_jwt.split(".")
+        if len(parts) != 3:
+            raise pyjwt.exceptions.DecodeError("Not enough segments")
+        # JWT compact serialisation strips base64 padding; restore it.
+        padded = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = _json.loads(base64.urlsafe_b64decode(padded))
+    except pyjwt.exceptions.DecodeError:
+        raise
+    except Exception as exc:
+        raise pyjwt.exceptions.DecodeError("Invalid JWT payload") from exc
+    if not isinstance(payload, dict):
+        raise pyjwt.exceptions.DecodeError("Invalid JWT payload: not a JSON object")
+    return payload
+
+
+def _decode_jwt_with_keys(token, jwks, algorithms, options):
+    """Decode a JWT by trying each key in the JWKS until one succeeds.
+
+    Entries that cannot be constructed into usable key objects (unsupported
+    kty, malformed key material, encryption-only keys, etc.) are skipped.
+    Terminal failures — expired token, missing claims, algorithm mismatch —
+    are raised immediately once a key has been successfully constructed.
+    """
+    key_list = jwks.get("keys", []) if isinstance(jwks, dict) else []
+    if not key_list:
+        raise pyjwt.exceptions.DecodeError("No keys available for validation")
+
+    last_exc = None
+    for jwk_data in key_list:
+        try:
+            key_obj = PyJWK(jwk_data)
+        except Exception as exc:
+            kid = (
+                jwk_data.get("kid", "<no kid>")
+                if isinstance(jwk_data, dict)
+                else "<unknown>"
+            )
+            logger.debug("Skipping unusable JWK entry (kid=%s): %s", kid, exc)
+            continue
+
+        try:
+            return pyjwt.decode(
+                token, key_obj.key, algorithms=algorithms, options=options
+            )
+        except (
+            pyjwt.exceptions.InvalidSignatureError,
+            pyjwt.exceptions.InvalidKeyError,
+            TypeError,
+        ) as exc:
+            # Wrong key or incompatible key type — try the next one
+            last_exc = exc
+
+    raise last_exc or pyjwt.exceptions.InvalidSignatureError("JWT validation failed")
 
 
 class ValidationError(Exception):
@@ -28,7 +99,7 @@ class JWT:
         provided input but it doesn't validate it in any way. If the
         input is invalid, an exception is raised."""
         self._encoded_jwt = encoded_jwt
-        self._claims = jwt.get_unverified_claims(encoded_jwt)
+        self._claims = _get_unverified_payload(encoded_jwt)
         self.settings = settings or api_token_auth_settings
 
     def validate(self, keys, audience, required_claims=_NOT_PROVIDED):
@@ -40,17 +111,15 @@ class JWT:
         if required_claims is _NOT_PROVIDED:
             required_claims = ["aud", "exp"]
 
+        require_aud = "aud" in required_claims
+        remaining_claims = [c for c in required_claims if c != "aud"]
+
         options = {
             "verify_aud": False,
+            "require": remaining_claims,
         }
 
-        require_aud = "aud" in required_claims
-        required_claims.remove("aud")
-
-        for required_claim in required_claims:
-            options[f"require_{required_claim}"] = True
-
-        jwt.decode(
+        _decode_jwt_with_keys(
             self._encoded_jwt,
             keys,
             algorithms=self.settings.ALLOWED_ALGORITHMS,
@@ -65,6 +134,12 @@ class JWT:
             claim_audiences = claims["aud"]
             if isinstance(claim_audiences, str):
                 claim_audiences = {claim_audiences}
+            elif isinstance(claim_audiences, list) and all(
+                isinstance(a, str) for a in claim_audiences
+            ):
+                claim_audiences = set(claim_audiences)
+            else:
+                raise ValidationError("Invalid audience.")
             if isinstance(audience, str):
                 audience = {audience}
             if len(set(audience).intersection(claim_audiences)) == 0:

--- a/helusers/tests/conftest.py
+++ b/helusers/tests/conftest.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timezone
 
+import jwt as pyjwt
 import pytest
 import responses
-from jose import jwt
 
 from helusers.settings import api_token_auth_settings
 
@@ -54,8 +54,8 @@ def encoded_jwt_factory(signing_key=rsa_key, **claims):
         if value is not None:
             jwt_data[name] = value
 
-    return jwt.encode(
-        jwt_data, key=signing_key.private_key_pem, algorithm=signing_key.jose_algorithm
+    return pyjwt.encode(
+        jwt_data, key=signing_key.private_key_pem, algorithm=signing_key.algorithm
     )
 
 

--- a/helusers/tests/keys.py
+++ b/helusers/tests/keys.py
@@ -1,5 +1,7 @@
-from jose import jwk
-from jose.constants import ALGORITHMS
+import json
+
+import jwt as pyjwt
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
 
 def _build_key(private_pem, public_pem):
@@ -7,10 +9,13 @@ def _build_key(private_pem, public_pem):
         pass
 
     key = _Key()
-    key.jose_algorithm = ALGORITHMS.RS256
+    key.algorithm = "RS256"
     key.private_key_pem = private_pem
     key.public_key_pem = public_pem
-    key.public_key_jwk = jwk.construct(public_pem, key.jose_algorithm).to_dict()
+    pub = load_pem_public_key(
+        public_pem.encode() if isinstance(public_pem, str) else public_pem
+    )
+    key.public_key_jwk = json.loads(pyjwt.algorithms.RSAAlgorithm.to_jwk(pub))
 
     return key
 

--- a/helusers/tests/test_jwt_token_authentication.py
+++ b/helusers/tests/test_jwt_token_authentication.py
@@ -1,9 +1,13 @@
+import base64
+import json
 import uuid
 
+import jwt as pyjwt
 import pytest
 from django.test.client import RequestFactory
 from rest_framework.exceptions import AuthenticationFailed
 
+from helusers.jwt import _decode_jwt_with_keys, _get_unverified_payload
 from helusers.oidc import AuthenticationError, RequestJWTAuthentication
 
 from .._oidc_auth_impl import ApiTokenAuthentication
@@ -349,3 +353,86 @@ def test_token_belonging_to_a_logged_out_session_is_not_accepted(sut):
 @pytest.mark.parametrize("amr", [None, "something", ["something"], ["one", "two"]])
 def test_amr_as_string_and_list_are_both_accepted(sut, amr):
     authentication_passes(sut=sut, amr=amr)
+
+
+def test_decode_jwt_skips_unusable_jwks_entries_before_valid_key():
+    """_decode_jwt_with_keys skips malformed/unsupported entries and uses the
+    valid key that follows them."""
+    now = unix_timestamp_now()
+    token = encoded_jwt_factory(
+        iss=ISSUER1,
+        sub=str(USER_UUID),
+        aud=AUDIENCE,
+        iat=now,
+        exp=now + 60,
+        signing_key=rsa_key,
+    )
+
+    mixed_jwks = {
+        "keys": [
+            {"kty": "UNKNOWN", "kid": "bad-unsupported"},  # unsupported type
+            {"kty": "RSA", "kid": "bad-malformed"},  # missing required fields
+            rsa_key.public_key_jwk,  # valid key — must be reached
+        ]
+    }
+
+    result = _decode_jwt_with_keys(
+        token,
+        mixed_jwks,
+        algorithms=["RS256"],
+        options={"verify_aud": False},
+    )
+    assert result["sub"] == str(USER_UUID)
+
+
+def test_decode_jwt_with_keys_raises_on_empty_jwks():
+    with pytest.raises(pyjwt.exceptions.DecodeError):
+        _decode_jwt_with_keys("a.b.c", {"keys": []}, algorithms=["RS256"], options={})
+
+
+def test_get_unverified_payload_raises_on_invalid_json():
+    not_json = base64.urlsafe_b64encode(b"not-json").rstrip(b"=").decode()
+    with pytest.raises(pyjwt.exceptions.DecodeError):
+        _get_unverified_payload(f"header.{not_json}.sig")
+
+
+def test_get_unverified_payload_raises_on_non_dict_payload():
+    array_payload = (
+        base64.urlsafe_b64encode(json.dumps([1, 2, 3]).encode()).rstrip(b"=").decode()
+    )
+    with pytest.raises(pyjwt.exceptions.DecodeError):
+        _get_unverified_payload(f"header.{array_payload}.sig")
+
+
+def test_get_unverified_payload_raises_on_invalid_utf8():
+    with pytest.raises(pyjwt.exceptions.DecodeError):
+        _get_unverified_payload(b"\xff\xfe invalid utf-8")
+
+
+def test_decode_jwt_skips_ec_key_before_rsa_signing_key():
+    """An EC key (constructs fine but wrong type for RS256) must be skipped so
+    the subsequent RSA key is still tried."""
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    ec_jwk = json.loads(
+        pyjwt.algorithms.ECAlgorithm.to_jwk(
+            ec.generate_private_key(ec.SECP256R1()).public_key()
+        )
+    )
+
+    now = unix_timestamp_now()
+    token = encoded_jwt_factory(
+        iss=ISSUER1,
+        sub=str(USER_UUID),
+        aud=AUDIENCE,
+        iat=now,
+        exp=now + 60,
+        signing_key=rsa_key,
+    )
+
+    mixed_jwks = {"keys": [ec_jwk, rsa_key.public_key_jwk]}
+
+    result = _decode_jwt_with_keys(
+        token, mixed_jwks, algorithms=["RS256"], options={"verify_aud": False}
+    )
+    assert result["sub"] == str(USER_UUID)

--- a/helusers/views.py
+++ b/helusers/views.py
@@ -13,7 +13,7 @@ from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic.base import RedirectView
-from jose import JOSEError
+from jwt.exceptions import PyJWTError
 
 from . import oidc
 from .jwt import JWT, ValidationError
@@ -103,7 +103,7 @@ class OIDCBackChannelLogout(View):
 
             if "nonce" in jwt.claims:
                 raise ValidationError()
-        except (JOSEError, KeyError, ValidationError):
+        except (PyJWTError, KeyError, ValidationError):
             return None
 
         return jwt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "cachetools>=3.0.0",
     "deprecation>=2",
     "requests",
-    "python-jose",
+    "PyJWT>=2",
+    "cryptography",
 ]
 
 [project.urls]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=City-of-Helsinki_django-helusers
 sonar.organization=city-of-helsinki
-sonar.python.version=3.10
-sonar.python.coverage.reportPaths=coverage.xml
-sonar.test.inclusions=**/tests/**/*
+sonar.python.version=3.10,3.11,3.12,3.13,3.14
+sonar.python.coverage.reportPaths=.coverage-reports/coverage*.xml
+sonar.test.inclusions=**/tests/**
 sonar.exclusions=**/migrations/*,pipelines/**/*


### PR DESCRIPTION
python-jose has a vulnerable transitive dependency on ecdsa (GHSA-wj6h-64fc-37mp) with no patched version available.

Replace with PyJWT + cryptography which provide equivalent JWT decoding, signature verification, and JWK handling.

- helusers/jwt.py: use pyjwt for decode/unverified claims; add _decode_jwt_with_keys() to iterate JWKS keys
- helusers/_oidc_auth_impl.py: JWTError -> PyJWTError
- helusers/views.py: JOSEError -> PyJWTError
- helusers/tests/keys.py: build JWK via cryptography + RSAAlgorithm.to_jwk(); rename jose_algorithm -> algorithm
- helusers/tests/conftest.py: use pyjwt.encode()
- pyproject.toml: replace python-jose with PyJWT + cryptography
- update pre-commit tool versions

Refs: [RATYK-22](https://helsinkisolutionoffice.atlassian.net/browse/RATYK-22)

[RATYK-22]: https://helsinkisolutionoffice.atlassian.net/browse/RATYK-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT decoding and claim handling for more reliable token authentication.
  * Updated JWT-related error handling so authentication and OIDC back-channel logout validation fail safely on invalid tokens.
* **Tests**
  * Expanded JWT unit test coverage for JWKS key selection and multiple invalid-payload scenarios.
* **Chores**
  * Updated pre-commit hook versions and refreshed test/coverage analysis settings to Python 3.12.
  * Migrated JWT support from python-jose to PyJWT/cryptography.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->