### PR TITLE
feat: change login method from GET to POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,10 +438,14 @@ SOCIAL_AUTH_TUNNISTAMO_AUTH_EXTRA_ARGUMENTS = {"ui_locales": "fi"}
 other default language. If you don't want to set a default language at all, use an empty string `""` as the language
 code.
 
-When this setting is in place, languages can be requested using query param `ui_locales=<language code>` when starting
-the login process, for example in your template
-```
-<a href="{% url 'helusers:auth_login' %}?next=/foobar/&ui_locales=en">Login in English</a>
+When this setting is in place, languages can be requested using the parameter `ui_locales=<language code>` when
+starting the login process. Login initiation uses a POST request, for example in your template:
+<form method="post" action="{% url 'helusers:auth_login' %}">
+    {% csrf_token %}
+    <input type="hidden" name="next" value="/foobar/">
+    <input type="hidden" name="ui_locales" value="en">
+    <button type="submit">Login in English</button>
+</form>
 ```
 
 #### Disabling password logins

--- a/helusers/templates/admin/hel_login.html
+++ b/helusers/templates/admin/hel_login.html
@@ -14,9 +14,16 @@
 <div id="helsinki-login">
     <p>Kirjaudu sisään Helsingin kaupungin työntekijän tunnuksella:</p>
     <div id="top-bottom-margins">
-        <a href="{{ helsinki_login_url }}{% if redirect_path %}?next={{ redirect_path }}{% endif %}">
-            <button id="helsinki-login-btn" class="button grp-button grp-default" type="button">Helsinki Login</button>
-        </a>
+        <form method="post" action="{{ helsinki_login_url }}">
+            {% csrf_token %}
+            {% if redirect_path %}
+            <input type="hidden" name="next" value="{{ redirect_path }}">
+            {% endif %}
+            {% if request.GET.ui_locales %}
+            <input type="hidden" name="ui_locales" value="{{ request.GET.ui_locales }}">
+            {% endif %}
+            <input id="helsinki-login-btn" class="button" type="submit" value="Helsinki Login">
+        </form>
     </div>
 {% if not password_login_disabled %}
     <p>

--- a/helusers/tests/test_admin.py
+++ b/helusers/tests/test_admin.py
@@ -1,5 +1,10 @@
+from unittest import mock
+
 import pytest
 from django.contrib.auth import get_user_model
+from django.http import HttpResponse
+from django.middleware.csrf import get_token
+from django.test import Client, override_settings
 from django.urls import reverse
 from pytest_django.asserts import assertContains
 from social_django.models import UserSocialAuth
@@ -24,6 +29,88 @@ def test_admin_index(client):
     assertContains(
         response, "Kirjaudu sisään Helsingin kaupungin työntekijän tunnuksella"
     )
+    assertContains(response, '<form method="post" action="/helauth/login/">')
+    assertContains(
+        response,
+        '<input type="hidden" name="csrfmiddlewaretoken"',
+    )
+    assertContains(
+        response,
+        '<input type="hidden" name="next" value="/admin/">',
+    )
+
+
+@pytest.mark.django_db
+def test_django_admin_login_post_preserves_request(client):
+    response = client.post(
+        reverse("helusers:auth_login"),
+        data={"next": "/admin/", "ui_locales": "en"},
+    )
+
+    assert response.status_code == 307
+    assert response.url == (
+        "/pysocial/login/tunnistamo/?next=%2Fadmin%2F&ui_locales=en"
+    )
+
+
+@pytest.mark.django_db
+def test_django_admin_login_get_is_not_allowed(client):
+    response = client.get(
+        reverse("helusers:auth_login"),
+        data={"next": "/admin/", "ui_locales": "en"},
+    )
+
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_django_admin_login_post_reaches_social_auth(client):
+    with mock.patch(
+        "social_django.views.do_auth",
+        return_value=HttpResponse(status=204),
+    ) as do_auth:
+        response = client.post(
+            reverse("helusers:auth_login"),
+            data={"next": "/admin/"},
+            follow=True,
+        )
+
+    assert response.status_code == 204
+    assert response.redirect_chain == [
+        ("/pysocial/login/tunnistamo/?next=%2Fadmin%2F", 307)
+    ]
+    request = do_auth.call_args.args[0].strategy.request
+    assert request.method == "POST"
+    assert request.POST["next"] == "/admin/"
+
+
+@pytest.mark.django_db
+@override_settings(
+    CSRF_USE_SESSIONS=True,
+    MIDDLEWARE=[
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+    ],
+)
+def test_django_admin_login_post_preserves_session_csrf():
+    client = Client(enforce_csrf_checks=True)
+    response = client.get(reverse("admin:index"), follow=True)
+    csrf_token = get_token(response.wsgi_request)
+
+    with mock.patch(
+        "social_django.views.do_auth",
+        return_value=HttpResponse(status=204),
+    ) as do_auth:
+        response = client.post(
+            reverse("helusers:auth_login"),
+            data={"next": "/admin/", "csrfmiddlewaretoken": csrf_token},
+            follow=True,
+        )
+
+    assert response.status_code == 204
+    assert do_auth.call_args.args[0].strategy.request.method == "POST"
 
 
 @pytest.mark.django_db

--- a/helusers/views.py
+++ b/helusers/views.py
@@ -8,6 +8,8 @@ from django.contrib.auth.views import LogoutView as DjangoLogoutView
 from django.core.signals import setting_changed
 from django.dispatch import receiver
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.middleware.csrf import get_token
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
@@ -42,6 +44,7 @@ class LogoutCompleteView(DjangoLogoutView):
 
 class LoginView(RedirectView):
     permanent = False
+    http_method_names = ["post"]
 
     def get_redirect_url(self, *args, **kwargs):
         # We make sure the user is logged out first, because otherwise
@@ -49,9 +52,16 @@ class LoginView(RedirectView):
         # method is connected to an existing user account.
         logout(self.request)
 
+        # In session based CSRF (CSRF_USE_SESSIONS) the CSRF token is stored
+        # server side. Calling logout() wipes this stored data which in
+        # turn would cause a 403 when the 307 redirects the POST to the next endpoint.
+        # Calling get_token ensures that CsrfViewMiddleware adds the token to the
+        # newly created session.
+        get_token(self.request)
+
         url = reverse("social:begin", kwargs=dict(backend="tunnistamo"))
-        redirect_to = self.request.GET.get(REDIRECT_FIELD_NAME)
-        lang = self.request.GET.get(LANGUAGE_FIELD_NAME)
+        redirect_to = self.request.POST.get(REDIRECT_FIELD_NAME)
+        lang = self.request.POST.get(LANGUAGE_FIELD_NAME)
 
         query_params = OrderedDict()
         if redirect_to:
@@ -62,6 +72,12 @@ class LoginView(RedirectView):
             url += "?" + urlencode(query_params)
 
         return url
+
+    def post(self, request, *args, **kwargs):
+        return redirect(
+            self.get_redirect_url(*args, **kwargs),
+            preserve_request=True,
+        )
 
 
 class OIDCBackChannelLogout(View):


### PR DESCRIPTION
This change has been made to provide compatibility for social-auth-app-django v6.0.0, which removed support for GET and only allows now POST.

Refs: RATYK-209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin Helsinki login now submits via **POST**, carrying `next` and `ui_locales` in hidden fields.
* **Bug Fixes**
  * Preserves the intended redirect destination and language preference during the sign-in redirect flow.
  * Redirect handling now reads `next`/language from **POST** data when available.
* **Documentation**
  * Updated language preference documentation to demonstrate POST form usage with CSRF and hidden `next`/`ui_locales`.
* **Tests**
  * Expanded coverage for POST behavior (including CSRF), correct redirect targets, and rejection of disallowed GET requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->